### PR TITLE
ENH: add EpicsSignal/RO precision classes

### DIFF
--- a/nslsii/devices.py
+++ b/nslsii/devices.py
@@ -3,10 +3,30 @@ import datetime
 from ophyd import (Device, Component as Cpt,
                    EpicsSignal, EpicsSignalRO, DeviceStatus)
 
-_time_fmtstr = '%Y-%m-%d %H:%M:%S'
+
+class EpicsSignalOverridePrecRO(EpicsSignalRO):
+    def __init__(self, *args, precision=4, **kwargs):
+        self._precision = precision
+        super().__init__(*args, **kwargs)
+
+    @property
+    def precision(self):
+        return self._precision
+
+
+class EpicsSignalOverridePrec(EpicsSignal):
+    def __init__(self, *args, precision=4, **kwargs):
+        self._precision = precision
+        super().__init__(*args, **kwargs)
+
+    @property
+    def precision(self):
+        return self._precision
 
 
 class TwoButtonShutter(Device):
+    _time_fmtstr = '%Y-%m-%d %H:%M:%S'
+
     # TODO: this needs to be fixed in EPICS as these names make no sense
     # the value coming out of the PV does not match what is shown in CSS
     open_cmd = Cpt(EpicsSignal, 'Cmd:Opn-Cmd', string=True)


### PR DESCRIPTION
Originally implemented at [SMI](https://github.com/NSLS-II-SMI/profile_collection/blob/70909a1916168872d98795cdd219ab18c01d5c39/startup/09-machine.py#L30-L47) by @danielballan. Recently adopted at [XPD](https://github.com/NSLS-II-XPD/profile_collection/blob/cb9e79e9a19fcefb73935020d1a27590a68d1d78/startup/12-rga.py#L5-L22).