### PR TITLE
Update eurotherm

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+exclude = .git,__pycache__,build,dist,versioneer.py,{{ cookiecutter.package_dir_name }}/_version.py,docs/source/conf.py

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-exclude = .git,__pycache__,build,dist,versioneer.py,{{ cookiecutter.package_dir_name }}/_version.py,docs/source/conf.py
+exclude = .git,__pycache__,build,dist,versioneer.py,nslsii/_version.py,docs/source/conf.py

--- a/nslsii/ad33.py
+++ b/nslsii/ad33.py
@@ -89,7 +89,7 @@ class StatsPluginV33(PluginBase):
     Due to https://github.com/areaDetector/ADCore/pull/333
     """
     _default_suffix = 'Stats1:'
-    _suffix_re = 'Stats\d:'
+    _suffix_re = r'Stats\d:'
     _html_docs = ['NDPluginStats.html']
     _plugin_type = 'NDPluginStats'
 

--- a/nslsii/temperature_controllers.py
+++ b/nslsii/temperature_controllers.py
@@ -25,7 +25,6 @@ class Eurotherm(Device):
         self._set_lock = threading.Lock()
 
         # defining these here so that they can be used by `set` and `start`
-        self._status = None
         self._cb_timer = None
         self._cid = None
 
@@ -47,7 +46,7 @@ class Eurotherm(Device):
 
         # define some required values
         set_value = value
-        self._status = DeviceStatus(self)
+        status = DeviceStatus(self)
 
         initial_timestamp = None
 
@@ -62,7 +61,7 @@ class Eurotherm(Device):
                                                           self.timeout.get()))
             self._set_lock.release()
             self.readback.clear_sub(status_indicator)
-            self._status._finished(success=False)
+            status._finished(success=False)
 
         self._cb_timer = threading.Timer(self.timeout.get(), timer_cleanup)
 
@@ -76,7 +75,7 @@ class Eurotherm(Device):
             if abs(value - set_value) < tolerance:
                 if initial_timestamp:
                     if (timestamp - initial_timestamp) > equilibrium_time:
-                        self._status._finished()
+                        status._finished()
                         self._cb_timer.cancel()
                         self._set_lock.release()
                         self.readback.clear_sub(status_indicator)
@@ -92,7 +91,7 @@ class Eurotherm(Device):
         self._cid = self.readback.subscribe(status_indicator)
 
         # hand the status object back to the RE
-        return self._status
+        return status
 
     def stop(self):
         # overide the lock, cancel the timer and remove the subscription on any

--- a/nslsii/temperature_controllers.py
+++ b/nslsii/temperature_controllers.py
@@ -55,7 +55,7 @@ class Eurotherm(Device):
         tolerance = self.tolerance.get()
 
         # setup a cleanup function for the timer, this matches including
-        # timeout in `status` but also ensures that the callback us removed.
+        # timeout in `status` but also ensures that the callback is removed.
         def timer_cleanup():
             print('Set of {} timed out after {} s'.format(self.name,
                                                           self.timeout.get()))

--- a/nslsii/tests/temperature_controllers_test.py
+++ b/nslsii/tests/temperature_controllers_test.py
@@ -44,14 +44,15 @@ def test_Eurotherm(RE):
 
         # check that the readback value is within euro.tolerance of 100
         assert abs(euro.readback.get() - 100) <= euro.tolerance.get()
+        assert len(euro.readback._callbacks['value']) == 0  # ensure cb is gone
 
         # test that the set will fail after 'timeout'
         euro.timeout.set(1)
         with pytest.raises(FailedStatus):
-            RE(mv(euro,100))
+            RE(mv(euro, 100))
         # ensure callback is removed
         assert len(euro.readback._callbacks['value']) == 0
-        euro.timeout.set(500) # reset to default for the following tests.
+        euro.timeout.set(500)  # reset to default for the following tests.
 
         # test that the lock prevents setting while set in progress
         with pytest.raises(Exception):

--- a/nslsii/tests/temperature_controllers_test.py
+++ b/nslsii/tests/temperature_controllers_test.py
@@ -1,4 +1,4 @@
-from nslsii.temperature_controllers import Eurotherm
+from nslsii.temperature_controllers import Eurotherm, SetInProgress
 from bluesky.plan_stubs import mv
 from bluesky import RunEngine
 from bluesky.utils import FailedStatus
@@ -55,7 +55,7 @@ def test_Eurotherm(RE):
         euro.timeout.set(500)  # reset to default for the following tests.
 
         # test that the lock prevents setting while set in progress
-        with pytest.raises(Exception):
+        with pytest.raises(SetInProgress):
             for i in range(2):  # The previous set may or may not be complete
                 euro.set(100)
 


### PR DESCRIPTION
## Description of issue
This PR is a response to issue #45. Essentially we can get into the situation where a callback 'hangs' because after a timeout error it is not removed from the readback signal. A second non-critical issue was raised, which is that we should be using threading.Lock objects instead of boolean objects as locks.
## Resolution
1. It adds a `threading.Timer` object that is used to do the timeout loop (instead of using the timeout in DeviceStatus).
2. it replaces the previous 'boolean' lock with a `threading.lock`.

The purpose of (1) is that currently the callback is not removed from readback when the timeout error is raised. So we could get into the situation whereby we never remove the callback. Moving the timeout process to a `threading.Timer` object associated allows the callback to be removed from readback after the timeout.
## Testing
The built in Travis pytest was updated to test these additions, including ensuring that the callback is removed on a timeout error.