### PR TITLE
Change count from 5 to 10 in TwoButtonShutter in devices.py

### DIFF
--- a/nslsii/devices.py
+++ b/nslsii/devices.py
@@ -60,7 +60,7 @@ class TwoButtonShutter(Device):
             nonlocal count
             value = cmd_enums[int(value)]
             count += 1
-            if count > 5:
+            if count > 10:
                 cmd_sig.clear_sub(cmd_retry_cb)
                 self._set_st = None
                 self.status.clear_sub(shutter_cb)


### PR DESCRIPTION
This was observed at the XFP experiment, that 5 attempts weren't enough to open the PPS shutter. Decided with @mrakitin to bump it to 10.