### PR TITLE
add a set of generic EPS two state devices

### DIFF
--- a/nslsii/EPS_devices/valves_and_shutters.py
+++ b/nslsii/EPS_devices/valves_and_shutters.py
@@ -96,21 +96,21 @@ class EPSTwoStateDevice(Device):
 
     _state1_cmd = FmtCpt(EpicsSignal,
                          '{self.prefix}Cmd:{self._state1_pv_uid}-Cmd',
-                         string=True)
+                         string=True, kind='omitted')
     _state2_cmd = FmtCpt(EpicsSignal,
                          '{self.prefix}Cmd:{self._state2_pv_uid}-Cmd',
-                         string=True)
+                         string=True, kind='omitted')
 
     status = Cpt(EpicsSignalRO, 'Pos-Sts', string=True)
 
-    enabled_status = Cpt(EpicsSignalRO, 'Enbl-Sts', string=True)
+    enabled_status = Cpt(EpicsSignalRO, 'Enbl-Sts', string=True, kind='config')
 
     _fail_to_state1 = FmtCpt(EpicsSignalRO,
                              '{self.prefix}Sts:Fail{self._state1_pv_uid}-Sts',
-                             string=True)
+                             string=True, kind='omitted')
     _fail_to_state2 = FmtCpt(EpicsSignalRO,
                              '{self.prefix}Sts:Fail{self._state2_pv_uid}-Sts',
-                             string=True)
+                             string=True, kind='omitted')
 
     def set(self, val):
         if self._set_st is not None:
@@ -156,36 +156,6 @@ class EPSTwoStateDevice(Device):
         self.status.subscribe(state_cb)
 
         return st
-
-    def stop(self, success):
-        import time
-        prev_st = self._set_st
-        cmd_sig = self._cmd_map[self._stop_str]
-        stop_val = self._target_map[self._stop_str]
-
-        if prev_st is not None:
-            while not prev_st.done:
-                time.sleep(.1)
-        self._was_stopped = (stop_val == self.status.get())
-        st = self.set(cmd_sig)
-        while not st.done:
-            time.sleep(self._retry_sleep_time)
-
-    def resume(self):
-        import time
-        cmd_sig = self._cmd_map[self._resume_str]
-        prev_st = self._set_st
-        if prev_st is not None:
-            while not prev_st.done:
-                time.sleep(.1)
-        if not self._was_stopped:
-            st = self.set(cmd_sig)
-            while not st.done:
-                time.sleep(self._retry_sleep_time)
-
-    def unstage(self):
-        self._was_stopped = True
-        return super().unstage()
 
 
 class PneumaticActuator(EPSTwoStateDevice):

--- a/nslsii/EPS_devices/valves_and_shutters.py
+++ b/nslsii/EPS_devices/valves_and_shutters.py
@@ -82,7 +82,7 @@ class EPSTwoStateDevice(Device):
             self._stop_str = self._state2_str
             self._resume_str = self._state1_str
         else:
-            raise nslsiiValves_and_ShuttersValueError(
+            raise NSLSIIValvesAndShuttersValueError(
                 'the kwarg ``stop_str`` in the EpicsTwoStateDevice class '
                 '``__init__`` method needs to be None or needs to match one of '
                 'the kwargs ``state1_str`` or ``state2_str``')

--- a/nslsii/EPS_devices/valves_and_shutters.py
+++ b/nslsii/EPS_devices/valves_and_shutters.py
@@ -53,7 +53,6 @@ class EPSTwoStateDevice(Device):
         The PV associated with moving to 'state 1' is derived from the
         ``prefix`` and the ``state1_pv_uid`` using the following format:
         ``'{prefix}Cmd:{state1_pv_uid}-Cmd'``
-
    '''
 
     def __init__(self, *, prefix, name,
@@ -288,7 +287,6 @@ class GateValve(EPSTwoStateDevice):
         state, the default is 0.5 s.
     **kwargs : dict, optional
         The kwargs passed to the ``ophyd.Device`` ``__init__`` method
-
     '''
 
     def __init__(self, *, prefix, name,
@@ -347,7 +345,6 @@ class PhotonShutter(EPSTwoStateDevice):
         state, the default is 0.5 s.
     **kwargs : dict, optional
         The kwargs passed to the ``ophyd.Device`` ``__init__`` method
-
     '''
 
     def __init__(self, *, prefix, name,

--- a/nslsii/EPS_devices/valves_and_shutters.py
+++ b/nslsii/EPS_devices/valves_and_shutters.py
@@ -159,6 +159,10 @@ class EPSTwoStateDevice(Device):
 
         return st
 
+    def stop():
+        self.status.clear_sub(state_cb)
+        self._set_st._finished(succsess=False)
+        super().stop()
 
 class PneumaticActuator(EPSTwoStateDevice):
     '''An ``ophyd.Device`` for EPS driven pneumatic actuators at NSLS-II.

--- a/nslsii/EPS_devices/valves_and_shutters.py
+++ b/nslsii/EPS_devices/valves_and_shutters.py
@@ -126,7 +126,7 @@ class EPSTwoStateDevice(Device):
         def state_cb(value, timestamp, **kwargs):
             value = enums[int(value)]
             if value == target_val:
-                self._set_st._finished()
+                st._finished()
                 self._set_st = None
                 self.status.clear_sub(state_cb)
 
@@ -139,6 +139,8 @@ class EPSTwoStateDevice(Device):
             count += 1
             if count > self._num_retries:
                 cmd_sig.clear_sub(cmd_retry_cb)
+                self._set_st = None
+                self.status.clear_sub(state_cb)
                 st._finished(success=False)
             if value == 'None':
                 if not st.done:

--- a/nslsii/EPS_devices/valves_and_shutters.py
+++ b/nslsii/EPS_devices/valves_and_shutters.py
@@ -62,7 +62,10 @@ class EPSTwoStateDevice(Device):
                  num_retries=1, retry_sleep_time=0.5,
                  stop_str=None, **kwargs):
 
-        super().__init__(prefix, name, **kwargs)
+        self._state1_pv_uid = state1_pv_uid
+        self._state2_pv_uid = state2_pv_uid
+
+        super().__init__(prefix=prefix, name=name, **kwargs)
 
         self._set_st = None
         self.read_attrs = ['status']
@@ -70,8 +73,6 @@ class EPSTwoStateDevice(Device):
         self._state2_val = state2_val
         self._state1_str = state1_str
         self._state2_str = state2_str
-        self._state1_pv_uid = state1_pv_uid
-        self._state2_pv_uid = state2_pv_uid
         self._num_retries = num_retries
         self._retry_sleep_time = retry_sleep_time
         if stop_str == state1_str:

--- a/nslsii/EPS_devices/valves_and_shutters.py
+++ b/nslsii/EPS_devices/valves_and_shutters.py
@@ -123,7 +123,7 @@ class EPSTwoStateDevice(Device):
             raise RuntimeError(
                 f'trying to set {self.name} while another set is in progress')
 
-        if self.enabled_status.get()=='False':
+        if self.enabled_status.get() == 'False':
             raise NSLSIIValvesAndShuttersEnableError(
                 f'Attempted to set {self.name} to {val}, but it is disabled '
                 f'check the read only attribute {self.name}.enabled_status '

--- a/nslsii/EPS_devices/valves_and_shutters.py
+++ b/nslsii/EPS_devices/valves_and_shutters.py
@@ -164,9 +164,9 @@ class EPSTwoStateDevice(Device):
         self._set_st._finished(success=False)
         super().stop()
 
+
 class PneumaticActuator(EPSTwoStateDevice):
     '''An ``ophyd.Device`` for EPS driven pneumatic actuators at NSLS-II.
-
 
     This is for use with NSLS-II EPS based pneumatic actuators that have two
     distinct states 'In' and 'Out' and are actuated into these two states by
@@ -188,9 +188,9 @@ class PneumaticActuator(EPSTwoStateDevice):
     name : str, keyword only
         The name of the device as will be reported via read()
     state1_val : float, int or str, optional
-        The value displayed when the device is read that signifys state 1
+        The value displayed when the device is read that signifies state 1
     state2_val : float, int or str, optional
-        The value displayed when the device is read that signifys state 2
+        The value displayed when the device is read that signifies state 2
     state1_str : str, optional
         The string value to be passed to ``RE(mv(device, val))`` to move to
         state 1
@@ -226,7 +226,7 @@ class PneumaticActuator(EPSTwoStateDevice):
 
 
 class GateValve(EPSTwoStateDevice):
-    '''An ``ophyd.Device`` for EPS driven gate valves at NSLS-II
+    '''An ``ophyd.Device`` for EPS driven gate valves at NSLS-II.
 
     This is for use with NSLS-II EPS based gate valves that have two
     distinct states 'Open' and 'Close' and are actuated into these two states
@@ -247,9 +247,9 @@ class GateValve(EPSTwoStateDevice):
     name : str, keyword only
         The name of the device as will be reported via read()
     state1_val : float, int or str, optional
-        The value displayed when the device is read that signifys state 1
+        The value displayed when the device is read that signifies state 1
     state2_val : float, int or str, optional
-        The value displayed when the device is read that signifys state 2
+        The value displayed when the device is read that signifies state 2
     state1_str : str, optional
         The string value to be passed to ``RE(mv(device, val))`` to move to
         state 1
@@ -305,9 +305,9 @@ class PhotonShutter(EPSTwoStateDevice):
     name : str, keyword only
         The name of the device as will be reported via read()
     state1_val : float, int or str, optional
-        The value displayed when the device is read that signifys state 1
+        The value displayed when the device is read that signifies state 1
     state2_val : float, int or str, optional
-        The value displayed when the device is read that signifys state 2
+        The value displayed when the device is read that signifies state 2
     state1_str : str, optional
         The string value to be passed to ``RE(mv(device, val))`` to move to
         state 1
@@ -316,7 +316,7 @@ class PhotonShutter(EPSTwoStateDevice):
         state 2
     num_retries : int, optional
         This number of attempts at changing the state prior to raising an
-        error, the default is 5.
+        error, the default is 10.
     retry_sleep_time : float, optional
         This is the time in seconds to wait between retries on changing the
         state, the default is 0.5 s.

--- a/nslsii/EPS_devices/valves_and_shutters.py
+++ b/nslsii/EPS_devices/valves_and_shutters.py
@@ -9,12 +9,12 @@ class nslsiiValves_and_ShuttersValueError(ValueError):
     pass
 
 
-class EpicsTwoStateDevice(Device):
-    '''An ``ophyd.Device`` class for two state Epics objects.
+class EPSTwoStateDevice(Device):
+    '''An ``ophyd.Device`` class for two state EPS objects at NSLS-II.
 
     This is a base class that should be used as a parent for classes related
-    to pneumatic actuators, gate valves, photon shutters or any other objects
-    that have 2 distinct states.
+    to pneumatic actuators, gate valves, photon shutters or any other NSLS-II
+    EPS objects that have 2 distinct states .
 
     Parameters
     ----------
@@ -37,7 +37,7 @@ class EpicsTwoStateDevice(Device):
     state2_pv_uid : str, optional
         The unique part of the EPICS PV for the state 2 command(see note below)
     num_retries : int, optional
-        This number of attempts at changing the state prior to raising an
+        The number of attempts at changing the state prior to raising an
         error, the default is 1.
     retry_sleep_time : float, optional
         This is the time in seconds to wait between retries on changing the
@@ -105,16 +105,17 @@ class EpicsTwoStateDevice(Device):
 
     enabled_status = Cpt(EpicsSignalRO, 'Enbl-Sts', string=True)
 
-    _fail_to_state2 = FmtCpt(EpicsSignalRO,
-                             '{self.prefix}Sts:Fail{self._state2_pv_uid}-Sts',
-                             string=True)
     _fail_to_state1 = FmtCpt(EpicsSignalRO,
                              '{self.prefix}Sts:Fail{self._state1_pv_uid}-Sts',
+                             string=True)
+    _fail_to_state2 = FmtCpt(EpicsSignalRO,
+                             '{self.prefix}Sts:Fail{self._state2_pv_uid}-Sts',
                              string=True)
 
     def set(self, val):
         if self._set_st is not None:
-            raise RuntimeError('trying to set while a set is in progress')
+            raise RuntimeError(
+                f'trying to set {self.name} while a set is in progress')
 
         cmd_sig = self._cmd_map[val]
         target_val = self._target_map[val]
@@ -145,8 +146,8 @@ class EpicsTwoStateDevice(Device):
                     cmd_sig.set(1)
                     ts = datetime.datetime.fromtimestamp(
                         timestamp).strftime(self._time_fmtstr)
-                    print('** ({}) Had to reactuate shutter while {}ing'
-                          ''.format(ts, val))
+                    print(f'** ({ts}) Had to reactuate {self.name} while'
+                          f'moving to {val}')
                 else:
                     cmd_sig.clear_sub(cmd_retry_cb)
 
@@ -187,7 +188,7 @@ class EpicsTwoStateDevice(Device):
         return super().unstage()
 
 
-class PneumaticActuator(EpicsTwoStateDevice):
+class PneumaticActuator(EPSTwoStateDevice):
     '''An ``ophyd.Device`` for EPS driven pneumatic actuators at NSLS-II
 
 
@@ -248,7 +249,7 @@ class PneumaticActuator(EpicsTwoStateDevice):
         super().__init__(prefix, name, **kwargs)
 
 
-class GateValve(EpicsTwoStateDevice):
+class GateValve(EPSTwoStateDevice):
     '''An ``ophyd.Device`` for EPS driven gate valves at NSLS-II
 
     This is for use with NSLS-II EPS based gate valves that have two
@@ -305,7 +306,7 @@ class GateValve(EpicsTwoStateDevice):
         super().__init__(prefix, name, **kwargs)
 
 
-class PhotonShutter(EpicsTwoStateDevice):
+class PhotonShutter(EPSTwoStateDevice):
     '''An ``ophyd.Device`` for EPS driven photon shutters at NSLS-II
 
     This is for use with NSLS-II EPS based photon shutters that have two

--- a/nslsii/EPS_devices/valves_and_shutters.py
+++ b/nslsii/EPS_devices/valves_and_shutters.py
@@ -5,7 +5,7 @@ from ophyd.device import (Component as Cpt, FormattedComponent as FmtCpt,
 import time
 
 
-class nslsiiValves_and_ShuttersValueError(ValueError):
+class NSLSIIValvesAndShuttersValueError(ValueError):
     pass
 
 
@@ -14,7 +14,7 @@ class EPSTwoStateDevice(Device):
 
     This is a base class that should be used as a parent for classes related
     to pneumatic actuators, gate valves, photon shutters or any other NSLS-II
-    EPS objects that have 2 distinct states .
+    EPS objects that have 2 distinct states.
 
     Parameters
     ----------
@@ -23,9 +23,9 @@ class EPSTwoStateDevice(Device):
     name : str, keyword only
         The name of the device as will be reported via read()
     state1_val : float, int or str, optional
-        The value displayed when the device is read that signifys state 1
+        The value displayed when the device is read that signifies state 1
     state2_val : float, int or str, optional
-        The value displayed when the device is read that signifys state 2
+        The value displayed when the device is read that signifies state 2
     state1_str : str, optional
         The string value to be passed to ``RE(mv(device, val))`` to move to
         state 1
@@ -33,9 +33,9 @@ class EPSTwoStateDevice(Device):
         The string value to be passed to ``RE(mv(device, val))`` to move to
         state 2
     state1_pv_uid : str, optional
-        The unique part of the EPICS PV for the state 1 command(see note below)
+        The unique part of the EPICS PV for the state 1 command (see note below)
     state2_pv_uid : str, optional
-        The unique part of the EPICS PV for the state 2 command(see note below)
+        The unique part of the EPICS PV for the state 2 command (see note below)
     num_retries : int, optional
         The number of attempts at changing the state prior to raising an
         error, the default is 1.
@@ -83,8 +83,8 @@ class EPSTwoStateDevice(Device):
             self._resume_str = self._state1_str
         else:
             raise nslsiiValves_and_ShuttersValueError(
-                'the kwarg ``stop_str`` in the EpicsTwoStateDevice class'
-                '``__init__`` method needs to be None or needs to match one of'
+                'the kwarg ``stop_str`` in the EpicsTwoStateDevice class '
+                '``__init__`` method needs to be None or needs to match one of '
                 'the kwargs ``state1_str`` or ``state2_str``')
 
         self._cmd_map = {self._state1_str: self._state1_cmd,
@@ -115,7 +115,7 @@ class EPSTwoStateDevice(Device):
     def set(self, val):
         if self._set_st is not None:
             raise RuntimeError(
-                f'trying to set {self.name} while a set is in progress')
+                f'trying to set {self.name} while another set is in progress')
 
         cmd_sig = self._cmd_map[val]
         target_val = self._target_map[val]
@@ -159,7 +159,7 @@ class EPSTwoStateDevice(Device):
 
 
 class PneumaticActuator(EPSTwoStateDevice):
-    '''An ``ophyd.Device`` for EPS driven pneumatic actuators at NSLS-II
+    '''An ``ophyd.Device`` for EPS driven pneumatic actuators at NSLS-II.
 
 
     This is for use with NSLS-II EPS based pneumatic actuators that have two

--- a/nslsii/EPS_devices/valves_and_shutters.py
+++ b/nslsii/EPS_devices/valves_and_shutters.py
@@ -161,7 +161,7 @@ class EPSTwoStateDevice(Device):
 
     def stop():
         self.status.clear_sub(state_cb)
-        self._set_st._finished(succsess=False)
+        self._set_st._finished(success=False)
         super().stop()
 
 class PneumaticActuator(EPSTwoStateDevice):

--- a/nslsii/EPS_devices/valves_and_shutters.py
+++ b/nslsii/EPS_devices/valves_and_shutters.py
@@ -1,0 +1,364 @@
+import datetime
+from ophyd import Device, EpicsSignal, EpicsSignalRO
+from ophyd.device import (Component as Cpt, FormattedComponent as FmtCpt,
+                          DeviceStatus)
+import time
+
+
+class nslsiiValves_and_ShuttersValueError(ValueError):
+    pass
+
+
+class EpicsTwoStateDevice(Device):
+    '''An ``ophyd.Device`` class for two state Epics objects.
+
+    This is a base class that should be used as a parent for classes related
+    to pneumatic actuators, gate valves, photon shutters or any other objects
+    that have 2 distinct states.
+
+    Parameters
+    ----------
+    prefix : str, keyword only
+        The PV prefix for all components of the device
+    name : str, keyword only
+        The name of the device as will be reported via read()
+    state1_val : float, int or str, optional
+        The value displayed when the device is read that signifys state 1
+    state2_val : float, int or str, optional
+        The value displayed when the device is read that signifys state 2
+    state1_str : str, optional
+        The string value to be passed to ``RE(mv(device, val))`` to move to
+        state 1
+    state2_str : str, optional
+        The string value to be passed to ``RE(mv(device, val))`` to move to
+        state 2
+    state1_pv_uid : str, optional
+        The unique part of the EPICS PV for the state 1 command(see note below)
+    state2_pv_uid : str, optional
+        The unique part of the EPICS PV for the state 2 command(see note below)
+    num_retries : int, optional
+        This number of attempts at changing the state prior to raising an
+        error, the default is 1.
+    retry_sleep_time : float, optional
+        This is the time in seconds to wait between retries on changing the
+        state, the default is 0.5 s.
+    stop_str : str or None, optional
+        The value of ``state1_str`` or ``state2_str`` to be called in the
+        ``stop`` method. The default, if None is entered, is ``state2_str``.
+    **kwargs : dict, optional
+        The kwargs passed to the ``ophyd.Device`` ``__init__`` method
+
+    ..note ::
+
+        The PV associated with moving to 'state 1' is derived from the
+        ``prefix`` and the ``state1_pv_uid`` using the following format:
+        ``'{prefix}Cmd:{state1_pv_uid}-Cmd'``
+
+   '''
+
+    def __init__(self, *, prefix, name,
+                 state1_val='Open', state2_val='Closed',
+                 state1_str='open', state2_str='close',
+                 state1_pv_uid='Opn', state2_pv_uid='Cls',
+                 num_retries=1, retry_sleep_time=0.5,
+                 stop_str=None, **kwargs):
+
+        super().__init__(prefix, name, **kwargs)
+
+        self._set_st = None
+        self.read_attrs = ['status']
+        self._state1_val = state1_val
+        self._state2_val = state2_val
+        self._state1_str = state1_str
+        self._state2_str = state2_str
+        self._state1_pv_uid = state1_pv_uid
+        self._state2_pv_uid = state2_pv_uid
+        self._num_retries = num_retries
+        self._retry_sleep_time = retry_sleep_time
+        if stop_str == state1_str:
+            self._stop_str = self._state1_str
+            self._resume_str = self._state2_str
+        elif stop_str == state2_str or stop_str is None:
+            self._stop_str = self._state2_str
+            self._resume_str = self._state1_str
+        else:
+            raise nslsiiValves_and_ShuttersValueError(
+                'the kwarg ``stop_str`` in the EpicsTwoStateDevice class'
+                '``__init__`` method needs to be None or needs to match one of'
+                'the kwargs ``state1_str`` or ``state2_str``')
+
+        self._cmd_map = {self._state1_str: self._state1_cmd,
+                         self._state2_str: self._state2_cmd}
+        self._target_map = {self._state1_str: self._state1_val,
+                            self._state2_str: self._state2_val}
+
+        self._time_fmtstr = '%Y-%m-%d %H:%M:%S'
+
+    _state1_cmd = FmtCpt(EpicsSignal,
+                         '{self.prefix}Cmd:{self._state1_pv_uid}-Cmd',
+                         string=True)
+    _state2_cmd = FmtCpt(EpicsSignal,
+                         '{self.prefix}Cmd:{self._state2_pv_uid}-Cmd',
+                         string=True)
+
+    status = Cpt(EpicsSignalRO, 'Pos-Sts', string=True)
+
+    enabled_status = Cpt(EpicsSignalRO, 'Enbl-Sts', string=True)
+
+    _fail_to_state2 = FmtCpt(EpicsSignalRO,
+                             '{self.prefix}Sts:Fail{self._state2_pv_uid}-Sts',
+                             string=True)
+    _fail_to_state1 = FmtCpt(EpicsSignalRO,
+                             '{self.prefix}Sts:Fail{self._state1_pv_uid}-Sts',
+                             string=True)
+
+    def set(self, val):
+        if self._set_st is not None:
+            raise RuntimeError('trying to set while a set is in progress')
+
+        cmd_sig = self._cmd_map[val]
+        target_val = self._target_map[val]
+
+        st = self._set_st = DeviceStatus(self)
+        enums = self.status.enum_strs
+
+        def state_cb(value, timestamp, **kwargs):
+            value = enums[int(value)]
+            if value == target_val:
+                self._set_st._finished()
+                self._set_st = None
+                self.status.clear_sub(state_cb)
+
+        cmd_enums = cmd_sig.enum_strs
+        count = 0
+
+        def cmd_retry_cb(value, timestamp, **kwargs):
+            nonlocal count
+            value = cmd_enums[int(value)]
+            count += 1
+            if count > self._num_retries:
+                cmd_sig.clear_sub(cmd_retry_cb)
+                st._finished(success=False)
+            if value == 'None':
+                if not st.done:
+                    time.sleep(self._retry_sleep_time)
+                    cmd_sig.set(1)
+                    ts = datetime.datetime.fromtimestamp(
+                        timestamp).strftime(self._time_fmtstr)
+                    print('** ({}) Had to reactuate shutter while {}ing'
+                          ''.format(ts, val))
+                else:
+                    cmd_sig.clear_sub(cmd_retry_cb)
+
+        cmd_sig.subscribe(cmd_retry_cb, run=False)
+        cmd_sig.set(1)
+        self.status.subscribe(state_cb)
+
+        return st
+
+    def stop(self, success):
+        import time
+        prev_st = self._set_st
+        cmd_sig = self._cmd_map[self._stop_str]
+        stop_val = self._target_map[self._stop_str]
+
+        if prev_st is not None:
+            while not prev_st.done:
+                time.sleep(.1)
+        self._was_stopped = (stop_val == self.status.get())
+        st = self.set(cmd_sig)
+        while not st.done:
+            time.sleep(self._retry_sleep_time)
+
+    def resume(self):
+        import time
+        cmd_sig = self._cmd_map[self._resume_str]
+        prev_st = self._set_st
+        if prev_st is not None:
+            while not prev_st.done:
+                time.sleep(.1)
+        if not self._was_stopped:
+            st = self.set(cmd_sig)
+            while not st.done:
+                time.sleep(self._retry_sleep_time)
+
+    def unstage(self):
+        self._was_stopped = True
+        return super().unstage()
+
+
+class PneumaticActuator(EpicsTwoStateDevice):
+    '''An ``ophyd.Device`` for EPS driven pneumatic actuators at NSLS-II
+
+
+    This is for use with NSLS-II EPS based pneumatic actuators that have two
+    distinct states 'In' and 'Out' and are actuated into these two states by
+    the PV's ``'{prefix}Cmd:In-Cmd'`` and ``'{prefix}Cmd:out-Cmd'``.
+
+    The basic use case is to define the device using the line:
+
+    ``my_pneumatic_actuator = PneumaticActuator(prefix='a_PV_prefix',
+                                                name='my_pneumatic_actuator')``
+
+    which can then be actuated by:
+    ``RE(mv(my_pneumatic_actuator, 'in')`` or
+    ``RE(mv(my_pneumatic_actuator, 'out')``
+
+    Parameters
+    ----------
+    prefix : str, keyword only
+        The PV prefix for all components of the device
+    name : str, keyword only
+        The name of the device as will be reported via read()
+    state1_val : float, int or str, optional
+        The value displayed when the device is read that signifys state 1
+    state2_val : float, int or str, optional
+        The value displayed when the device is read that signifys state 2
+    state1_str : str, optional
+        The string value to be passed to ``RE(mv(device, val))`` to move to
+        state 1
+    state2_str : str, optional
+        The string value to be passed to ``RE(mv(device, val))`` to move to
+        state 2
+    num_retries : int, optional
+        This number of attempts at changing the state prior to raising an
+        error, the default is 1.
+    retry_sleep_time : float, optional
+        This is the time in seconds to wait between retries on changing the
+        state, the default is 0.5 s.
+    stop_str : str or None, optional
+        The value of ``state1_str`` or ``state2_str`` to be called in the
+        ``stop`` method. The default, if None is entered, is ``state2_str``.
+    **kwargs : dict, optional
+        The kwargs passed to the ``ophyd.Device`` ``__init__`` method
+    '''
+
+    def __init__(self, *, prefix, name,
+                 state1_val='In', state2_val='Out',
+                 state1_str='in', state2_str='out',
+                 num_retries=1, retry_sleep_time=0.5,
+                 stop_str=None, **kwargs):
+
+        kwargs = dict(state1_pv_uid='In', state2_pv_uid='Out',
+                      state1_val=state1_val, state2_val=state2_val,
+                      state1_str=state1_str, state2_str=state2_str,
+                      num_retries=num_retries,
+                      retry_sleep_time=retry_sleep_time,
+                      stop_str=stop_str, **kwargs)
+        super().__init__(prefix, name, **kwargs)
+
+
+class GateValve(EpicsTwoStateDevice):
+    '''An ``ophyd.Device`` for EPS driven gate valves at NSLS-II
+
+    This is for use with NSLS-II EPS based gate valves that have two
+    distinct states 'Open' and 'Close' and are actuated into these two states
+    by the PV's ``'{prefix}Cmd:Opn-Cmd'`` and ``'{prefix}Cmd:Cls-Cmd'``.
+
+    The basic use case is to define the device using the line:
+
+    ``my_gate_valve = GateValve(prefix='a_PV_prefix', name='my_gate_valve')``
+
+    which can then be actuated by:
+    ``RE(mv(my_gate_valve, 'open')`` or
+    ``RE(mv(my_gate_valve, 'close')``
+
+    Parameters
+    ----------
+    prefix : str, keyword only
+        The PV prefix for all components of the device
+    name : str, keyword only
+        The name of the device as will be reported via read()
+    state1_val : float, int or str, optional
+        The value displayed when the device is read that signifys state 1
+    state2_val : float, int or str, optional
+        The value displayed when the device is read that signifys state 2
+    state1_str : str, optional
+        The string value to be passed to ``RE(mv(device, val))`` to move to
+        state 1
+    state2_str : str, optional
+        The string value to be passed to ``RE(mv(device, val))`` to move to
+        state 2
+    num_retries : int, optional
+        This number of attempts at changing the state prior to raising an
+        error, the default is 1.
+    retry_sleep_time : float, optional
+        This is the time in seconds to wait between retries on changing the
+        state, the default is 0.5 s.
+    **kwargs : dict, optional
+        The kwargs passed to the ``ophyd.Device`` ``__init__`` method
+
+    '''
+
+    def __init__(self, *, prefix, name,
+                 state1_val='Open', state2_val='Closed',
+                 state1_str='open', state2_str='close',
+                 num_retries=1, retry_sleep_time=0.5,
+                 stop_str=None, **kwargs):
+
+        kwargs = dict(state1_pv_uid='Opn', state2_pv_uid='Cls',
+                      state1_val=state1_val, state2_val=state2_val,
+                      state1_str=state1_str, state2_str=state2_str,
+                      num_retries=num_retries,
+                      retry_sleep_time=retry_sleep_time,
+                      stop_str=stop_str, **kwargs)
+        super().__init__(prefix, name, **kwargs)
+
+
+class PhotonShutter(EpicsTwoStateDevice):
+    '''An ``ophyd.Device`` for EPS driven photon shutters at NSLS-II
+
+    This is for use with NSLS-II EPS based photon shutters that have two
+    distinct states 'Open' and 'Close' and are actuated into these two states
+    by the PV's ``'{prefix}Cmd:Opn-Cmd'`` and ``'{prefix}Cmd:Cls-Cmd'``. This
+    is different from the ``GateValve`` class as it has, as standard, a larger
+    number of retries (``num_retries``) as default.
+
+    The basic use case is to define the device using the line:
+
+    ``my_shutter = PhotonShutter(prefix='a_PV_prefix', name='my_shutter')``
+
+    which can then be actuated by:
+    ``RE(mv(my_shutter, 'open')`` or
+    ``RE(mv(my_shutter, 'close')``
+
+    Parameters
+    ----------
+    prefix : str, keyword only
+        The PV prefix for all components of the device
+    name : str, keyword only
+        The name of the device as will be reported via read()
+    state1_val : float, int or str, optional
+        The value displayed when the device is read that signifys state 1
+    state2_val : float, int or str, optional
+        The value displayed when the device is read that signifys state 2
+    state1_str : str, optional
+        The string value to be passed to ``RE(mv(device, val))`` to move to
+        state 1
+    state2_str : str, optional
+        The string value to be passed to ``RE(mv(device, val))`` to move to
+        state 2
+    num_retries : int, optional
+        This number of attempts at changing the state prior to raising an
+        error, the default is 5.
+    retry_sleep_time : float, optional
+        This is the time in seconds to wait between retries on changing the
+        state, the default is 0.5 s.
+    **kwargs : dict, optional
+        The kwargs passed to the ``ophyd.Device`` ``__init__`` method
+
+    '''
+
+    def __init__(self, *, prefix, name,
+                 state1_val='Open', state2_val='Closed',
+                 state1_str='open', state2_str='close',
+                 num_retries=5, retry_sleep_time=0.5,
+                 stop_str=None, **kwargs):
+
+        kwargs = dict(state1_pv_uid='Opn', state2_pv_uid='Cls',
+                      state1_val=state1_val, state2_val=state2_val,
+                      state1_str=state1_str, state2_str=state2_str,
+                      num_retries=num_retries,
+                      retry_sleep_time=retry_sleep_time,
+                      stop_str=stop_str, **kwargs)
+        super().__init__(prefix, name, **kwargs)

--- a/nslsii/EPS_devices/valves_and_shutters.py
+++ b/nslsii/EPS_devices/valves_and_shutters.py
@@ -33,9 +33,11 @@ class EPSTwoStateDevice(Device):
         The string value to be passed to ``RE(mv(device, val))`` to move to
         state 2
     state1_pv_uid : str, optional
-        The unique part of the EPICS PV for the state 1 command (see note below)
+        The unique part of the EPICS PV for the state 1 command (see note
+        below)
     state2_pv_uid : str, optional
-        The unique part of the EPICS PV for the state 2 command (see note below)
+        The unique part of the EPICS PV for the state 2 command (see note
+        below)
     num_retries : int, optional
         The number of attempts at changing the state prior to raising an
         error, the default is 1.
@@ -84,7 +86,7 @@ class EPSTwoStateDevice(Device):
         else:
             raise NSLSIIValvesAndShuttersValueError(
                 'the kwarg ``stop_str`` in the EpicsTwoStateDevice class '
-                '``__init__`` method needs to be None or needs to match one of '
+                '``__init__`` method needs to be None or needs to match one of'
                 'the kwargs ``state1_str`` or ``state2_str``')
 
         self._cmd_map = {self._state1_str: self._state1_cmd,
@@ -159,9 +161,9 @@ class EPSTwoStateDevice(Device):
 
         return st
 
-    def stop():
+    def stop(self, success=False):
         self.status.clear_sub(state_cb)
-        self._set_st._finished(success=False)
+        self._set_st._finished(success=success)
         super().stop()
 
 

--- a/nslsii/devices.py
+++ b/nslsii/devices.py
@@ -74,7 +74,7 @@ class TwoButtonShutter(Device):
                         .strftime(_time_fmtstr)
                     if count > 2:
                         msg = '** ({}) Had to reactuate shutter while {}ing'
-                        print(msg.format(ts, val if val is not 'Close'
+                        print(msg.format(ts, val if val != 'Close'
                                          else val[:-1]))
                 else:
                     cmd_sig.clear_sub(cmd_retry_cb)

--- a/nslsii/tests/EPS_devices.py
+++ b/nslsii/tests/EPS_devices.py
@@ -1,10 +1,85 @@
+from nslsii.EPS_devices.valves_and_shutters import (
+    EPSTwoStateDevice, NSLSIIValvesAndShuttersEnableError)
+from bluesky import RunEngine
+from bluesky.plan_stubs import mv
+from bluesky.utils import FailedStatus
+from ophyd import Device, Component as Cpt, EpicsSignal
+import os
+import subprocess
+import sys
+import time
+import pytest
 
-from nslsii.EPS_devices.valves_and_shutters import EPSTwoStateDevice
+RE=RunEngine()
 
 
 def test_EPSTwoStateDevice():
-    '''A smoke test of the EPSTwoStateDevice class
+    '''A test of the EPSTwoStateDevice class.
+
+    This test covers 3 known failure modes which are modelled using the caproto
+    IOC found at ``nslsii/iocs/eps_two_state_ioc_sim/EPSTwoStateIOC``. The 3
+    failure modes are:
+        1. Retry Activation Error.
+            - Actuating the 'cmd_sig' PV does not always work on the first try.
+        2. Hardware Activation Error.
+            - In this case the hardware reports an error in the move which
+              leaves the ``fail_to_cls`` attribute reading ``True``
+        3. Activation disabled.
+            - The Hardware is in a 'disabled' states as indicated by the
+            ``enbl_sts`` attribute being false.
     '''
 
-    shutter = EPSTwoStateDevice(prefix='test', name='shutter')
-    assert(hasattr(shutter, 'read'))
+    class _IOC_control(Device):
+        enbl_sts = Cpt(EpicsSignal, 'Enbl-Sts', string=True,
+                       kind='omitted')
+
+        hw_error = Cpt(EpicsSignal, 'HwError-Sts', string=True,
+                           kind='omitted')
+
+        sts_error = Cpt(EpicsSignal, 'StsError-Sts', string=True,
+                            kind='omitted')
+
+    stdout = subprocess.PIPE
+    stdin = None
+
+    ioc_process = subprocess.Popen([sys.executable, '-m',
+                                    'caproto.tests.example_runner',
+                                    'nslsii.iocs.eps_two_state_ioc_sim'],
+                                   stdout=stdout, stdin=stdin,
+                                   env=os.environ)
+
+    time.sleep(1)  # allows the ioc to start properly
+    print(f'nslsii.ioc.eps_two_state_ioc_sim is now running')
+
+    # Wrap the rest in a try except to ensre that the ioc is killed.
+    try:
+        shutter = EPSTwoStateDevice(prefix='eps2state:', name='shutter')
+        ioc_control = _IOC_control(prefix='eps2state:', name='ioc_control')
+
+        time.sleep(1)
+
+        # two quick tests to ensure the devices and IOC are running.
+        assert(hasattr(shutter, 'read'))  # make sure that the device runs
+        assert shutter.read()['shutter_status']['value'] in ['Open','Closed']
+
+        # Retry activation error test by closing and opening succesfully
+        RE(mv(shutter, 'close'))
+        assert shutter.read()['shutter_status']['value'] == 'Closed'
+        time.sleep(0.05)
+        RE(mv(shutter, 'open'))
+        assert shutter.read()['shutter_status']['value'] == 'Open'
+
+        # Hardware failure test, should raise FailedStatus exception.
+        RE(mv(ioc_control.hw_error, 'True'))  # enable the hardware error
+        with pytest.raises(FailedStatus):
+            RE(mv(shutter, 'close'))
+        RE(mv(ioc_control.hw_error, 'False'))  # disable the hardware error
+
+        # Activation disabled test, should raise EnableError exception
+        RE(mv(ioc_control.enbl_sts, 'False'))
+        with pytest.raises(NSLSIIValvesAndShuttersEnableError):
+            RE(mv(shutter, 'open'))
+        RE(mv(ioc_control.enbl_sts, 'True'))
+
+    finally:
+        ioc_process.terminate()

--- a/nslsii/tests/EPS_devices.py
+++ b/nslsii/tests/EPS_devices.py
@@ -10,10 +10,13 @@ import sys
 import time
 import pytest
 
-RE=RunEngine()
+
+@pytest.fixture
+def RE():
+    return RunEngine()
 
 
-def test_EPSTwoStateDevice():
+def test_EPSTwoStateDevice(RE):
     '''A test of the EPSTwoStateDevice class.
 
     This test covers 3 known failure modes which are modelled using the caproto
@@ -34,10 +37,10 @@ def test_EPSTwoStateDevice():
                        kind='omitted')
 
         hw_error = Cpt(EpicsSignal, 'HwError-Sts', string=True,
-                           kind='omitted')
+                       kind='omitted')
 
         sts_error = Cpt(EpicsSignal, 'StsError-Sts', string=True,
-                            kind='omitted')
+                        kind='omitted')
 
     stdout = subprocess.PIPE
     stdin = None
@@ -60,7 +63,7 @@ def test_EPSTwoStateDevice():
 
         # two quick tests to ensure the devices and IOC are running.
         assert(hasattr(shutter, 'read'))  # make sure that the device runs
-        assert shutter.read()['shutter_status']['value'] in ['Open','Closed']
+        assert shutter.read()['shutter_status']['value'] in ['Open', 'Closed']
 
         # Retry activation error test by closing and opening succesfully
         RE(mv(shutter, 'close'))

--- a/nslsii/tests/EPS_devices.py
+++ b/nslsii/tests/EPS_devices.py
@@ -1,10 +1,10 @@
 
 from nslsii.EPS_devices.valves_and_shutters import EPSTwoStateDevice
-import pytest
+
 
 def test_EPSTwoStateDevice():
     '''A smoke test of the EPSTwoStateDevice class
     '''
 
-    shutter=EPSTwoStateDevice(prefix='test', name='shutter')
-    assert(hasattr(shutter,'read'))
+    shutter = EPSTwoStateDevice(prefix='test', name='shutter')
+    assert(hasattr(shutter, 'read'))

--- a/nslsii/tests/EPS_devices.py
+++ b/nslsii/tests/EPS_devices.py
@@ -1,0 +1,10 @@
+
+from nslsii.EPS_devices.valves_and_shutters import EPSTwoStateDevice
+import pytest
+
+def test_EPSTwoStateDevice():
+    '''A smoke test of the EPSTwoStateDevice class
+    '''
+
+    shutter=EPSTwoStateDevice(prefix='test', name='shutter')
+    assert(hasattr(shutter,'read'))


### PR DESCRIPTION
This PR is designed to add some generic EPS two state `ophyd.Device`s (photon shutters, gate valves and pneumatic actuators). As these are common NSLS-II items we would prefer to have a common source for these, instead of the scattered large number we currently have.

These are based on what already exists on the floor, but are un-tested. I am opening the PR to get feedback on the overall structure of this. Tests will be added once the DAMA group decides how we should implement them (in particular the IOC's to test against).