### PR TITLE
add a collection of generic slit devices

### DIFF
--- a/nslsii/motor_devices/slits.py
+++ b/nslsii/motor_devices/slits.py
@@ -19,9 +19,9 @@ def slit(name='', axes={'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
 
     ..code ::
 
-        HorizSlit=BaffleSlit(name='Horiz_Slit',
-                             axes={'hg': '-Ax:HG}Mtr', 'hc':'-Ax:HC}Mtr'})
-        my_slit=HorizSlit(PV_prefix, name='my_slit')
+        HorizSlit = slit(name='Horiz_Slit',
+                         axes={'hg': '-Ax:HG}Mtr', 'hc':'-Ax:HC}Mtr'})
+        my_slit = HorizSlit(PV_prefix, name='my_slit')
 
     Parameters
     ----------
@@ -59,23 +59,16 @@ def slit(name='', axes={'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
 
 # FourBladeSlit class
 _fourblade_docstring = (
-    '''An ``ophyd.Device`` class to be used for 4 blade baffle slits at NSLS-II
+    '''An ``ophyd.Device`` class to be used for 4 blade slits at NSLS-II
 
-    This is generated using ``nslsii.motor_devices.slit`` and adds the default
+    This is generated using ``nslsii.motor_devices.slit`` and has the default
     components for a 4 blade slit. In particular, in addition to the components
-    for horizontal and vertical gap and centres it adds components for the
-    inboard (inb), outboard (out), top (top) and bottom (bot) blades.
+    for horizontal and vertical gap and centres (hg, hc, vg and vc) it has
+    components for the inboard (inb), outboard (out), top (top) and bottom
+    (bot) blades.
 
     Parameters
     ----------
-    components, dict
-        Maps the name for a motor attribute to the PVsuffix for the EpicsMotor
-        group. The default, which defines a basic slit with horizontal(h) and
-        vertical(v) gaps(g) and centres(c), is:
-        {'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
-         'vg': '-Ax:VG}Mtr', 'vc': '-Ax:VC}Mtr',
-         'inb': '-Ax:I}Mtr', 'out': '-Ax:O}Mtr',
-         'top': '-Ax:T}Mtr', 'bot': '-Ax:B}Mtr'}
     *args
         The arguments that will be passed down to the ``ophyd.Device``
         ``__init__`` call.
@@ -95,30 +88,23 @@ FourBladeSlit = slit(name='FourBladeSlit',
 _scanaperture_docstring = (
     '''An ``ophyd.Device`` class used for scan/aperture baffle slits at NSLS-II
 
-    This is a child of ``nslsii.motor_devices.BaffleSlit`` and adds the
-    default components for a baffle slit with 'scan' and 'aperture' motors. In
-    particular, in addition to the default components for horizontal and
-    vertical gap and centres from ``nslsii.motor_devices.BaffleSlit`` it adds
-    default components for the horizontal scan (hs), horizontal aperture (ha),
-    vertical scan (vs) and vertical aperture (va) motors.
+    This is generated using ``nslsii.motor_devices.slit`` and has the default
+    components for a slit with 'scan' and 'aperture' motors. In particular, in
+    addition to the components for horizontal and vertical gap and centres
+    (hg, hc, vg and vc) it has components for the horizontal scan (hs),
+    horizontal aperture (ha), vertical scan (vs) and vertical aperture (va).
 
     Parameters
     ----------
-    components, dict
-        Maps the name for a motor attribute to the PVsuffix for the EpicsMotor
-        group. The default, which defines a basic slit with horizontal(h) and
-        vertical(v) gaps(g) and centres(c), is:
-        {'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
-         'vg': '-Ax:VG}Mtr', 'vc': '-Ax:VC}Mtr',
-         'hs': '-Ax:HS}Mtr', 'ha': '-Ax:HA}Mtr',
-         'vs': '-Ax:VS}Mtr', 'va': '-Ax:VA}Mtr'}
     *args
-        The arguments that will be passed down to the ``Device`` ``__init__``
+        The arguments that will be passed down to the ``ophyd.Device``
+        ``__init__``
         call.
     **kwargs
-        The keyword arguments that will be passed down to the ``Device``
+        The keyword arguments that will be passed down to the ``ophyd.Device``
         ``__init__`` call.
     ''')
+
 ScanAndApertureSlit = slit(name='ScanAndApertureSlit',
                            axes={'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
                                  'vg': '-Ax:VG}Mtr', 'vc': '-Ax:VC}Mtr',

--- a/nslsii/motor_devices/slits.py
+++ b/nslsii/motor_devices/slits.py
@@ -84,7 +84,7 @@ _fourblade_docstring = (
         ``__init__`` call.
     ''')
 
-FourBladeSlit = slit(name='FourBladeBaffleSlit',
+FourBladeSlit = slit(name='FourBladeSlit',
                      axes={'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
                            'vg': '-Ax:VG}Mtr', 'vc': '-Ax:VC}Mtr',
                            'inb': '-Ax:I}Mtr', 'out': '-Ax:O}Mtr',

--- a/nslsii/motor_devices/slits.py
+++ b/nslsii/motor_devices/slits.py
@@ -1,0 +1,149 @@
+from ophyd import (Device, Component, EpicsMotor, PVPositioner, EpicsSignal,
+                   EpicsSignalRO)
+
+
+class BaffleSlit(Device):
+    '''An ``ophyd.Device`` class to be used as a base for'slits' at NSLS-II
+
+    This is the base class that should be a parent for the remaining slit
+    classes at NSLS-II. Slits are defined as anything that has at least one
+    settable 'opening' or 'aperture'. The default is a baffle slit with a
+    horizontal gap and centre (hg and hc) and a vertical gap and centre (vg and
+    vc). Other configurations can be created using the ``blades`` dict on
+    initialization. For instance to define a horizontal only slit use the
+    kwarg:
+      ``slit=BaffleSlit(PV_prefix, name='slit',
+                        components = {'hg': '-Ax:HG}Mtr', 'hc':'-Ax:HC}Mtr'})``
+
+    Parameters
+    ----------
+    components, dict
+        Maps the name for a motor attribute to the PVsuffix for the EpicsMotor
+        group. The default, which defines a basic slit with horizontal(h) and
+        vertical(v) gaps(g) and centres(c), is:
+        {'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
+         'vg': '-Ax:VG}Mtr', 'vc': '-Ax:VC}Mtr'}
+    *args
+        The arguments that will be passed down to the ``Device`` ``__init__``
+        call.
+    **kwargs
+        The keyword arguments that will be passed down to the ``Device``
+        ``__init__`` call.
+    '''
+
+    def __init__(self, *args,
+                 components={'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
+                             'vg': '-Ax:VG}Mtr', 'vc': '-Ax:VC}Mtr'},
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+        for name, PV_suffix in components.items():
+            setattr(self, name, Component(EpicsMotor, PV_suffix, name=name))
+
+
+class FourBladeBaffleSlit(BaffleSlit):
+    '''An ``ophyd.Device`` class to be used for 4 blade baffle slits at NSLS-II
+
+    This is a child of ``nslsii.motor_devices.BaffleSlit`` and adds the
+    default components for a 4 blade baffle slit. In particular, in addition to
+    the default components for horizontal and vertical gap and centres from
+    ``nslsii.motor_devices.BaffleSlit`` it adds default components for the
+    inboard (inb), outboard (out), top (top) and bottom (bot) blades.
+
+    Parameters
+    ----------
+    components, dict
+        Maps the name for a motor attribute to the PVsuffix for the EpicsMotor
+        group. The default, which defines a basic slit with horizontal(h) and
+        vertical(v) gaps(g) and centres(c), is:
+        {'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
+         'vg': '-Ax:VG}Mtr', 'vc': '-Ax:VC}Mtr',
+         'inb': '-Ax:I}Mtr', 'out': '-Ax:O}Mtr',
+         'top': '-Ax:T}Mtr', 'bot': '-Ax:B}Mtr'}
+    *args
+        The arguments that will be passed down to the ``Device`` ``__init__``
+        call.
+    **kwargs
+        The keyword arguments that will be passed down to the ``Device``
+        ``__init__`` call.
+    '''
+    def __init__(self, *args,
+                 components={'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
+                             'vg': '-Ax:VG}Mtr', 'vc': '-Ax:VC}Mtr',
+                             'inb': '-Ax:I}Mtr', 'out': '-Ax:O}Mtr',
+                             'top': '-Ax:T}Mtr', 'bot': '-Ax:B}Mtr'},
+                 **kwargs):
+        super().__init__(*args, components=components, **kwargs)
+
+
+class ScanAndApertureBaffleSlit(BaffleSlit):
+    '''An ``ophyd.Device`` class used for scan/aperture baffle slits at NSLS-II
+
+    This is a child of ``nslsii.motor_devices.BaffleSlit`` and adds the
+    default components for a baffle slit with 'scan' and 'aperture' motors. In
+    particular, in addition to the default components for horizontal and
+    vertical gap and centres from ``nslsii.motor_devices.BaffleSlit`` it adds
+    default components for the horizontal scan (hs), horizontal aperture (ha),
+    vertical scan (vs) and vertical aperture (va) motors.
+
+    Parameters
+    ----------
+    components, dict
+        Maps the name for a motor attribute to the PVsuffix for the EpicsMotor
+        group. The default, which defines a basic slit with horizontal(h) and
+        vertical(v) gaps(g) and centres(c), is:
+        {'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
+         'vg': '-Ax:VG}Mtr', 'vc': '-Ax:VC}Mtr',
+         'hs': '-Ax:HS}Mtr', 'ha': '-Ax:HA}Mtr',
+         'vs': '-Ax:VS}Mtr', 'va': '-Ax:VA}Mtr'}
+    *args
+        The arguments that will be passed down to the ``Device`` ``__init__``
+        call.
+    **kwargs
+        The keyword arguments that will be passed down to the ``Device``
+        ``__init__`` call.
+    '''
+    def __init__(self, *args,
+                 components={'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
+                             'vg': '-Ax:VG}Mtr', 'vc': '-Ax:VC}Mtr',
+                             'hs': '-Ax:HS}Mtr', 'ha': '-Ax:HA}Mtr',
+                             'vs': '-Ax:VS}Mtr', 'va': '-Ax:VA}Mtr'},
+                 **kwargs):
+        super().__init__(*args, components=components, **kwargs)
+
+
+class FrontEndSlits(Device):
+    '''An ``ophyd.Device`` class used for the front end slits at NSLS-II
+
+    This is a child of ``ophyd.Device`` and adds the default in order to
+    move the front-end slits, this differs from the
+    ``nslsii.motor_devices.slits`` as the comonents are not EpicsMotor records.
+
+    Parameters
+    ----------
+    *args
+        The arguments that will be passed down to the ``Device`` ``__init__``
+        call.
+    **kwargs
+        The keyword arguments that will be passed down to the ``Device``
+        ``__init__`` call.
+    '''
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    class _VirtualGap(PVPositioner):
+        readback = Component(EpicsSignalRO, 't2.C')
+        setpoint = Component(EpicsSignal, 'size')
+        done = Component(EpicsSignalRO, 'DMOV')
+        done_value = 1
+
+    class _VirtualCenter(PVPositioner):
+        readback = Component(EpicsSignalRO, 't2.D')
+        setpoint = Component(EpicsSignal, 'center')
+        done = Component(EpicsSignalRO, 'DMOV')
+        done_value = 1
+
+    hc = Component(_VirtualCenter, '-Ax:X}')
+    vc = Component(_VirtualCenter, '-Ax:Y}')
+    hg = Component(_VirtualGap, '-Ax:X}')
+    vg = Component(_VirtualGap, '-Ax:Y}')

--- a/nslsii/motor_devices/slits.py
+++ b/nslsii/motor_devices/slits.py
@@ -3,9 +3,7 @@ from ophyd import (Device, Component, EpicsMotor, PVPositioner, EpicsSignal,
 from ophyd.device import create_device_from_components
 
 
-def slit(name='', axes={'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
-                        'vg': '-Ax:VG}Mtr', 'vc': '-Ax:VC}Mtr'}, *,
-         docstring=None, default_read_attrs=None,
+def slit(name, axes=None, *, docstring=None, default_read_attrs=None,
          default_configuration_attrs=None):
     '''Returns an ``ophyd.Device`` class for 'slits' at NSLS-II
 
@@ -27,7 +25,7 @@ def slit(name='', axes={'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
     ----------
     name: str
         The name of the new ``ophyd.Device`` class.
-    components : dict
+    components : dict, optional
         Maps the name for a motor attribute to the PVsuffix for the EpicsMotor
         group. The default, which defines a basic slit with horizontal(h) and
         vertical(v) gaps(g) and centres(c), is:
@@ -42,6 +40,10 @@ def slit(name='', axes={'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
         Outside of Kind, control the default configuration_attrs list.
         Defaults to []
     '''
+
+    if axes is None:
+        axes = {'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
+                'vg': '-Ax:VG}Mtr', 'vc': '-Ax:VC}Mtr'},
 
     components = {}
     for name, PV_suffix in axes.items():

--- a/nslsii/motor_devices/slits.py
+++ b/nslsii/motor_devices/slits.py
@@ -77,12 +77,12 @@ _fourblade_docstring = (
         ``__init__`` call.
     ''')
 
-FourBladeSlit = slit(name='FourBladeSlit',
-                     axes={'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
-                           'vg': '-Ax:VG}Mtr', 'vc': '-Ax:VC}Mtr',
-                           'inb': '-Ax:I}Mtr', 'out': '-Ax:O}Mtr',
-                           'top': '-Ax:T}Mtr', 'bot': '-Ax:B}Mtr'},
-                     docstring=_fourblade_docstring)
+FourBladeSlits = slit(name='FourBladeSlits',
+                      axes={'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
+                            'vg': '-Ax:VG}Mtr', 'vc': '-Ax:VC}Mtr',
+                            'inb': '-Ax:I}Mtr', 'out': '-Ax:O}Mtr',
+                            'top': '-Ax:T}Mtr', 'bot': '-Ax:B}Mtr'},
+                      docstring=_fourblade_docstring)
 
 # ScanAndApertureSlit class
 _scanaperture_docstring = (
@@ -105,12 +105,12 @@ _scanaperture_docstring = (
         ``__init__`` call.
     ''')
 
-ScanAndApertureSlit = slit(name='ScanAndApertureSlit',
-                           axes={'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
-                                 'vg': '-Ax:VG}Mtr', 'vc': '-Ax:VC}Mtr',
-                                 'hs': '-Ax:HS}Mtr', 'ha': '-Ax:HA}Mtr',
-                                 'vs': '-Ax:VS}Mtr', 'va': '-Ax:VA}Mtr'},
-                           docstring=_scanaperture_docstring)
+ScanAndApertureSlits = slit(name='ScanAndApertureSlits',
+                            axes={'hg': '-Ax:HG}Mtr', 'hc': '-Ax:HC}Mtr',
+                                  'vg': '-Ax:VG}Mtr', 'vc': '-Ax:VC}Mtr',
+                                  'hs': '-Ax:HS}Mtr', 'ha': '-Ax:HA}Mtr',
+                                  'vs': '-Ax:VS}Mtr', 'va': '-Ax:VA}Mtr'},
+                            docstring=_scanaperture_docstring)
 
 
 class FrontEndSlits(Device):
@@ -136,13 +136,13 @@ class FrontEndSlits(Device):
     class _VirtualGap(PVPositioner):
         readback = Component(EpicsSignalRO, 't2.C')
         setpoint = Component(EpicsSignal, 'size')
-        done = Component(EpicsSignalRO, 'DMOV')
+        done = Component(EpicsSignalRO, 'DMOV', kind='config')
         done_value = 1
 
     class _VirtualCenter(PVPositioner):
         readback = Component(EpicsSignalRO, 't2.D')
         setpoint = Component(EpicsSignal, 'center')
-        done = Component(EpicsSignalRO, 'DMOV')
+        done = Component(EpicsSignalRO, 'DMOV', kind='omitted')
         done_value = 1
 
     hc = Component(_VirtualCenter, '-Ax:X}')

--- a/nslsii/tests/motor_devices_test.py
+++ b/nslsii/tests/motor_devices_test.py
@@ -1,0 +1,17 @@
+from nslsii.motor_devices.slits import FourBladeSlits, FrontEndSlits
+
+
+def test_FourBladeSlits():
+    '''smoke test of the FourBladeSlits class
+    '''
+
+    slits = FourBladeSlits('test', name='slits')
+    assert(hasattr(slits, 'hc'))
+
+
+def test_FEslits():
+    '''smoke test of the FEslits class
+    '''
+
+    FEslits = FrontEndSlits('test', name='FEslits')
+    assert(hasattr(FEslits, 'hc'))


### PR DESCRIPTION
This PR is designed to add some generic slit devices based on `ophyd.Devices` (FourBladeSlits, ScanAndApertureBaffleSlits and FrontEndSlits). As these are common NSLS-II items we would prefer to have a common source for these, instead of the scattered large number we currently have.

These are based on what already exists on the floor, but are un-tested. I am opening the PR to get feedback on the overall structure of this. Tests will be added once the DAMA group decides how we should implement them (in particular the IOC's to test against).