### PR TITLE
Update pv suffixes

### DIFF
--- a/nslsii/iocs/thermo_sim.py
+++ b/nslsii/iocs/thermo_sim.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+from caproto.server import pvproperty, PVGroup, ioc_arg_parser, run
+import numpy as np
+import time
+from textwrap import dedent
+
+
+class Thermo(PVGroup):
+    """
+    Simulates (poorly) an oscillating temperature controller.
+
+    Follows :math:`T_{output} = T_{var} exp^{-(t - t_0)/K} sin(ω t) + T_{setpoint}`
+
+    The default prefix is `thermo:`
+
+    Readonly PVs
+    ------------
+
+    I -> the current value
+
+    Control PVs
+    -----------
+
+    SP -> where to go
+    K -> the decay constant
+    omega -> the oscillation frequency
+    Tvar -> the scale of the oscillations
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._T0 = time.monotonic()
+
+    readback = pvproperty(value=0, dtype=float, read_only=True,
+                          name='I',
+                          mock_record='ai')
+
+    setpoint = pvproperty(value=100, dtype=float, name='SP')
+    K = pvproperty(value=10, dtype=float)
+    omega = pvproperty(value=np.pi, dtype=float)
+    Tvar = pvproperty(value=10, dtype=float)
+
+    @readback.scan(period=.1, use_scan_field=True)
+    async def readback(self, instance, async_lib):
+
+        def t_rbv(T0, setpoint, K, omega, Tvar,):
+            t = time.monotonic()
+            return ((Tvar *
+                     np.exp(-(t - self._T0) / K) *
+                     np.sin(omega * t)) +
+                    setpoint)
+
+        T = t_rbv(T0=self._T0,
+                  **{k: getattr(self, k).value
+                     for k in ['setpoint', 'K', 'omega', 'Tvar']})
+
+        await instance.write(value=T)
+
+    @setpoint.putter
+    async def setpoint(self, instance, value):
+        self._T0 = time.monotonic()
+        return value
+
+
+if __name__ == '__main__':
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix='thermo:',
+        desc=dedent(Thermo.__doc__))
+    ioc = Thermo(**ioc_options)
+    run(ioc.pvdb, **run_options)

--- a/nslsii/iocs/thermo_sim.py
+++ b/nslsii/iocs/thermo_sim.py
@@ -32,10 +32,10 @@ class Thermo(PVGroup):
         self._T0 = time.monotonic()
 
     readback = pvproperty(value=0, dtype=float, read_only=True,
-                          name='I',
+                          name='T-RB',
                           mock_record='ai')
 
-    setpoint = pvproperty(value=100, dtype=float, name='SP')
+    setpoint = pvproperty(value=100, dtype=float, name='T-SP')
     K = pvproperty(value=10, dtype=float)
     omega = pvproperty(value=np.pi, dtype=float)
     Tvar = pvproperty(value=10, dtype=float)

--- a/nslsii/iocs/thermo_sim.py
+++ b/nslsii/iocs/thermo_sim.py
@@ -9,7 +9,7 @@ class Thermo(PVGroup):
     """
     Simulates (poorly) an oscillating temperature controller.
 
-    Follows :math:`T_{output} = T_{var} exp^{-(t - t_0)/K} sin(ω t) 
+    Follows :math:`T_{output} = T_{var} exp^{-(t - t_0)/K} sin(ω t)
                    + T_{setpoint}`
 
     The default prefix is `thermo:`

--- a/nslsii/iocs/thermo_sim.py
+++ b/nslsii/iocs/thermo_sim.py
@@ -9,7 +9,8 @@ class Thermo(PVGroup):
     """
     Simulates (poorly) an oscillating temperature controller.
 
-    Follows :math:`T_{output} = T_{var} exp^{-(t - t_0)/K} sin(ω t) + T_{setpoint}`
+    Follows :math:`T_{output} = T_{var} exp^{-(t - t_0)/K} sin(ω t) 
+                   + T_{setpoint}`
 
     The default prefix is `thermo:`
 

--- a/nslsii/temperature_controllers.py
+++ b/nslsii/temperature_controllers.py
@@ -34,8 +34,8 @@ class Eurotherm(Device):
     tolerance = Cpt(Signal, value=1)
 
     # Add the readback and setpoint components
-    setpoint = Cpt(EpicsSignal, 'SP')
-    readback = Cpt(EpicsSignal, 'I')
+    setpoint = Cpt(EpicsSignal, 'T-SP')
+    readback = Cpt(EpicsSignal, 'T-I')
 
     # define the new set method with the new moving indicator
     def set(self, value):

--- a/nslsii/temperature_controllers.py
+++ b/nslsii/temperature_controllers.py
@@ -35,7 +35,7 @@ class Eurotherm(Device):
 
     # Add the readback and setpoint components
     setpoint = Cpt(EpicsSignal, 'T-SP')
-    readback = Cpt(EpicsSignal, 'T-I')
+    readback = Cpt(EpicsSignal, 'T-RB')
 
     # define the new set method with the new moving indicator
     def set(self, value):

--- a/nslsii/tests/temperature_controllers_test.py
+++ b/nslsii/tests/temperature_controllers_test.py
@@ -28,7 +28,7 @@ def test_Eurotherm(RE):
     # Start up an IOC based on the thermo_sim device in caproto.ioc_examples
     ioc_process = subprocess.Popen([sys.executable, '-m',
                                     'caproto.tests.example_runner',
-                                    'caproto.ioc_examples.thermo_sim'],
+                                    'nslsii.iocs.thermo_sim'],
                                    stdout=stdout, stdin=stdin,
                                    env=os.environ)
 


### PR DESCRIPTION
The IOC for the Eurotherm was updated some time ago but the ophyd object for it was not updated to mirror the new PV suffixes.