### PR TITLE
ENH: Baton IOC

### DIFF
--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -118,7 +118,7 @@ def configure_base(user_ns, broker_name, *,
         RE = RunEngine(md, **kwargs)
 
         if baton is not None:
-            for d in ['start', 'stop']:
+            for d in ['start']:
                 tok = RE.subscribe(baton.doc_callback, d)
                 baton.tokens.append(tok)
             RE.state_hook = baton.state_callback

--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -168,10 +168,10 @@ def configure_base(user_ns, broker_name, *,
         import matplotlib.pyplot as plt
         ns['plt'] = plt
         plt.ion()
-
-        # Make plots update live while scans run.
-        from bluesky.utils import install_kicker
-        install_kicker()
+        if bluesky.__version__ < '1.6':
+            # Make plots update live while scans run.
+            from bluesky.utils import install_kicker
+            install_kicker()
 
     if epics_context:
         # Create a context in the underlying EPICS client.

--- a/nslsii/baton.py
+++ b/nslsii/baton.py
@@ -86,3 +86,19 @@ class Baton(Device):
 
     def state_callback(self, new, old):
         self.state.put(new)
+
+
+class BatonDisplay(Device):
+    """
+    Read-only Ophyd object to wrap the "baton" IOC.
+
+    This is to populate a typhon screen.
+    """
+
+    baton = Cpt(EpicsSignalRO, "baton", string=True, kind="config")
+    host = Cpt(EpicsSignalRO, "host", string=True, kind="config")
+    pid = Cpt(EpicsSignalRO, "pid", kind="config")
+
+    current_uid = Cpt(EpicsSignalRO, "current_uid", string=True)
+    current_scanid = Cpt(EpicsSignalRO, "current_scanid")
+    state = Cpt(EpicsSignalRO, "state", string=True, kind="hinted")

--- a/nslsii/baton.py
+++ b/nslsii/baton.py
@@ -72,6 +72,7 @@ class Baton(Device):
                 self.baton.put("")
                 self.host.put("")
                 self.pid.put(0)
+                self.state.put("unknown")
             except Exception:
                 # if we fail in tear down 🤷
                 pass

--- a/nslsii/baton.py
+++ b/nslsii/baton.py
@@ -1,0 +1,85 @@
+import platform
+import os
+import uuid
+import atexit
+from ophyd import Device, Component as Cpt, EpicsSignal
+
+
+class Baton(Device):
+    """
+    Ophyd object to wrap the "baton" IOC
+
+    Examples
+    --------
+
+    >>>>  b = Baton(PREFX, name='baton')
+    >>>>  ip = get_ipython()
+    >>>>  configure_base(ip.user_ns, 'chx', acquire_baton=b.acquire_baton)
+
+    """
+
+    baton = Cpt(EpicsSignal, "baton", string=True)
+    host = Cpt(EpicsSignal, "host", string=True)
+    pid = Cpt(EpicsSignal, "pid")
+    last_uid = Cpt(EpicsSignal, "last_uid", string=True)
+    current_uid = Cpt(EpicsSignal, "current_uid", string=True)
+    state = Cpt(EpicsSignal, "state", string=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._clear_baton = None
+        self.tokens = []
+
+    def acquire_baton(self, steal_baton=False):
+        existing_baton = self.baton.get()
+        if existing_baton and not steal_baton:
+            old_host = self.host.get()
+            old_pid = self.pid.get()
+            raise RuntimeError(
+                f"There is already a RE claiming the baton. "
+                f"It was running on {old_host}:{old_pid}."
+            )
+
+        new_baton = str(uuid.uuid4())
+        self.baton.put(new_baton)
+        self.host.put(platform.node())
+        self.pid.put(os.getpid())
+
+        def check_baton():
+            ioc_baton = self.baton.get()
+            if ioc_baton != new_baton:
+                ioc_host = self.host.get()
+                ioc_pid = self.pid.get()
+                raise RuntimeError(
+                    f"This RE installed {new_baton} but the "
+                    f"IOC has {ioc_baton}. "
+                    f"The baton was intalled by {ioc_host}:{ioc_pid}"
+                )
+
+        self.install_clear_baton()
+        return check_baton
+
+    def install_clear_baton(self):
+        if self._clear_baton is not None:
+            return
+
+        def clear_baton(baton):
+            try:
+                self.baton.put("")
+                self.host.put("")
+                self.pid.put(0)
+            except Exception:
+                # if we fail in tear down 🤷
+                pass
+
+        atexit.register(clear_baton, self)
+        self._clear_baton = clear_baton
+
+    def doc_callback(self, name, doc):
+        if name == "start":
+            self.current_uid.put(doc["uid"])
+        elif name == "stop":
+            self.last_uid.put(doc["run_start"])
+
+    def state_callback(self, new, old):
+        self.state.put(new)

--- a/nslsii/iocs/baton.py
+++ b/nslsii/iocs/baton.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+from caproto.server import pvproperty, PVGroup
+from caproto.server import ioc_arg_parser, run
+from caproto import ChannelType
+from textwrap import dedent
+
+
+class IOC(PVGroup):
+    """
+    A Baton IOC for managing
+
+    """
+
+    baton = pvproperty(
+        value="",
+        dtype=ChannelType.STRING,
+        doc='"baton" for running RE',
+        mock_record="ai",
+    )
+    host = pvproperty(
+        value="",
+        dtype=ChannelType.STRING,
+        doc="host name of computer running RE",
+        mock_record="ai",
+    )
+    pid = pvproperty(
+        value=0, doc="pid of running RE on host", mock_record="ai"
+    )
+
+    last_uid = pvproperty(
+        value="",
+        dtype=ChannelType.STRING,
+        doc="Last finished uid.",
+        mock_record="ai",
+    )
+    current_uid = pvproperty(
+        value="",
+        dtype=ChannelType.STRING,
+        doc="UID currently being collected.",
+        mock_record="ai",
+    )
+    state = pvproperty(
+        value="unknown",
+        doc="current state of RE",
+        enum_strings=[
+            "unknown",
+            "idle",
+            "running",
+            "pausing",
+            "paused",
+            "halting",
+            "stopping",
+            "aborting",
+            "suspending",
+            "panicked",
+        ],
+        dtype=ChannelType.ENUM,
+        mock_record="ai",
+    )
+
+
+if __name__ == "__main__":
+
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix="XF31ID:", desc=dedent(IOC.__doc__)
+    )
+
+    ioc = IOC(**ioc_options)
+
+    run(ioc.pvdb, **run_options)

--- a/nslsii/iocs/baton.py
+++ b/nslsii/iocs/baton.py
@@ -58,8 +58,7 @@ class IOC(PVGroup):
     )
 
 
-if __name__ == "__main__":
-
+def main():
     ioc_options, run_options = ioc_arg_parser(
         default_prefix="XF31ID:", desc=dedent(IOC.__doc__)
     )
@@ -67,3 +66,7 @@ if __name__ == "__main__":
     ioc = IOC(**ioc_options)
 
     run(ioc.pvdb, **run_options)
+
+
+if __name__ == "__main__":
+    main()

--- a/nslsii/iocs/baton.py
+++ b/nslsii/iocs/baton.py
@@ -27,18 +27,17 @@ class IOC(PVGroup):
         value=0, doc="pid of running RE on host", mock_record="ai"
     )
 
-    last_uid = pvproperty(
+    current_uid = pvproperty(
         value="",
         dtype=ChannelType.STRING,
         doc="Last finished uid.",
         mock_record="ai",
     )
-    current_uid = pvproperty(
-        value="",
-        dtype=ChannelType.STRING,
-        doc="UID currently being collected.",
-        mock_record="ai",
+
+    current_scanid = pvproperty(
+        value=0, doc="Last finished scanid.", mock_record="ai"
     )
+
     state = pvproperty(
         value="unknown",
         doc="current state of RE",

--- a/nslsii/tests/test_baton.py
+++ b/nslsii/tests/test_baton.py
@@ -1,0 +1,84 @@
+import uuid
+import asyncio
+from bluesky import RunEngine
+from bluesky import plans as bps
+from nslsii.baton import Baton
+from nslsii import configure_base
+import pytest
+import subprocess
+import os
+
+
+@pytest.fixture(scope="function")
+def baton_ioc(request):
+    stdout = subprocess.PIPE
+    stdin = None
+    prefix = f"{str(uuid.uuid4())[:6]}:"
+    # Start up an IOC based on the thermo_sim device in caproto.ioc_examples
+    ioc_process = subprocess.Popen(
+        ["baton-ioc", "--prefix", prefix, "--list-pvs"],
+        stdout=stdout,
+        stdin=stdin,
+        env=os.environ,
+    )
+
+    def kill_ioc():
+        ioc_process.terminate()
+
+    request.addfinalizer(kill_ioc)
+    return prefix
+
+
+def test_baton(baton_ioc):
+    b = Baton(baton_ioc, name="b")
+    b.wait_for_connection(timeout=5)
+    b.read()
+
+    assert b.baton.get() == ""
+    cb = b.acquire_baton()
+    assert b.baton.get() != ""
+    cb()
+    cb()
+
+    with pytest.raises(RuntimeError):
+        b.acquire_baton()
+
+    cb2 = b.acquire_baton(steal_baton=True)
+    with pytest.raises(RuntimeError):
+        cb()
+
+    cb2()
+
+
+def _inner_test(RE, b):
+    assert b.baton.get() != ""
+    for _ in range(5):
+        uid, = RE(bps.count([]))
+        assert b.current_uid.get() == uid
+        assert b.current_scanid.get() == RE.md["scan_id"]
+
+    b.baton.put("")
+    with pytest.raises(RuntimeError):
+        RE([])
+
+
+def test_baton_RE(baton_ioc):
+    b = Baton(baton_ioc, name="b")
+    b.wait_for_connection(timeout=5)
+    assert b.baton.get() == ""
+    loop = asyncio.new_event_loop()
+    loop.set_debug(True)
+    RE = RunEngine({}, loop=loop, acquire_baton=b.acquire_baton)
+    RE.subscribe(b.doc_callback, "start")
+    RE.state_hook = b.state_callback
+    _inner_test(RE, b)
+
+
+def test_configure_base(baton_ioc):
+    out = {}
+    b = Baton(baton_ioc, name="b")
+    b.wait_for_connection(timeout=5)
+    configure_base(out, "temp", baton=b, magics=False)
+    RE = out["RE"]
+
+    _inner_test(RE, b)

--- a/setup.py
+++ b/setup.py
@@ -27,4 +27,9 @@ setuptools.setup(
     description='Tools for data collection and analysis at NSLS-II',
     author='Brookhaven National Laboratory',
     install_requires=requirements,
+    entry_points={
+        'console_scripts': [
+            'baton-ioc = nslsii.iocs.baton:main',
+            ]
+        }
 )


### PR DESCRIPTION
This is the companion PR to
https://github.com/bluesky/bluesky/pull/1246

Adds:

 - updates configure_base for bluesky changes
 - a Baton caproto IOC and matching ohpyd object with the hooks to
   interact with bluesky
 - a read only version of the ophyd object to back a typhon window


```python

from nslsii import configure_base
from nslsii.baton import Baton
from ophyd.sim import *


b = Baton('XF31ID:', name='b')

names = configure_base(get_ipython().user_ns, 'temp', baton=b)


```


```python
import os
os.environ['PYDM_EPICS_LIB'] = 'caproto'
from nslsii.baton import BatonDisplay

from qtpy.QtWidgets import QApplication
import typhon
app = QApplication.instance() or QApplication(['bluesky'])

bd = BatonDisplay('XF31ID:', name='b')
suite = typhon.TyphonSuite.from_device(bd)
suite.show()

app.exec_()

```