### PR TITLE
IPython exception logger

### DIFF
--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -13,7 +13,7 @@ def import_star(module, ns):
 
 def configure_base(user_ns, broker_name, *,
                    bec=True, epics_context=False, magics=True, mpl=True,
-                   ophyd_logging=True, pbar=True):
+                   ophyd_logging=True, pbar=True, ipython_exc_logging=True):
     """
     Perform base setup and instantiation of important objects.
 
@@ -61,6 +61,9 @@ def configure_base(user_ns, broker_name, *,
         ophyd.
     pbar : boolean, optional
         True by default. Set false to skip ProgressBarManager.
+    ipython_exc_logging : boolean, optional
+        True by default. Exception stack traces will be written to IPython log file
+        when IPython logging is enabled.
 
     Returns
     -------
@@ -147,6 +150,11 @@ def configure_base(user_ns, broker_name, *,
         ch = logging.StreamHandler()
         ch.setLevel(logging.ERROR)
         ophyd.ophydobj.logger.addHandler(ch)
+
+    if ipython_exc_logging:
+        # IPython logging must be enabled separately
+        from nslsii.common.ipynb.logutils import log_exception
+        get_ipython().set_custom_exc((BaseException,), log_exception)
 
     # convenience imports
     # some of the * imports are for 'back-compatibility' of a sort -- we have

--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -62,8 +62,8 @@ def configure_base(user_ns, broker_name, *,
     pbar : boolean, optional
         True by default. Set false to skip ProgressBarManager.
     ipython_exc_logging : boolean, optional
-        True by default. Exception stack traces will be written to IPython log file
-        when IPython logging is enabled.
+        True by default. Exception stack traces will be written to IPython
+        log file when IPython logging is enabled.
 
     Returns
     -------

--- a/nslsii/common/ipynb/logutils.py
+++ b/nslsii/common/ipynb/logutils.py
@@ -5,6 +5,10 @@ def log_exception(ipyshell, etype, evalue, tb, tb_offset=None):
     """A custom IPython exception handler that logs exception tracebacks to
     the IPython log file.
 
+    References:
+        https://ipython.readthedocs.io/en/stable/api/generated/IPython.core.interactiveshell.html
+        https://ipython.readthedocs.io/en/stable/api/generated/IPython.core.logger.html
+
     Usage:
         from nslsii.common.ipynb.logutils import log_exception
         get_ipython().set_custom_exc((BaseException, ), log_exception)

--- a/nslsii/common/ipynb/logutils.py
+++ b/nslsii/common/ipynb/logutils.py
@@ -1,0 +1,35 @@
+import traceback
+
+
+def log_exception(ipyshell, etype, evalue, tb, tb_offset=None):
+    """A custom IPython exception handler that logs exception tracebacks to
+    the IPython log file.
+
+    Usage:
+        from nslsii.common.ipynb.logutils import log_exception
+        get_ipython().set_custom_exc((BaseException, ), log_exception)
+
+        %logstart -o -t ipython_log/beamline.log rotate
+
+    Parameters
+    ----------
+    ipyshell : TerminalInteractiveShell
+
+    etype : type of evalue
+
+    evalue : BaseException
+
+    tb : traceback
+
+    tb_offset : ???
+
+    Returns
+    -------
+    list of traceback lines
+    """
+    tb_lines = traceback.format_exception(etype, evalue, tb)
+    for tb_line in tb_lines:
+        ipyshell.logger.log_write(tb_line, kind="output")
+    ipyshell.showtraceback((etype, evalue, tb), tb_offset=tb_offset)
+
+    return tb_lines

--- a/nslsii/tests/test_logutils.py
+++ b/nslsii/tests/test_logutils.py
@@ -1,0 +1,13 @@
+from unittest.mock import MagicMock
+
+import IPython.core.interactiveshell
+
+from nslsii.common.ipynb.logutils import log_exception
+
+
+def test_log_exception():
+    ip = IPython.core.interactiveshell.InteractiveShell()
+    ip.logger = MagicMock()
+    ip.set_custom_exc((BaseException, ), log_exception)
+    ip.run_cell("raise Exception")
+    ip.logger.log_write.assert_called_with("Exception\n", kind="output")


### PR DESCRIPTION
This PR adds one module with one function for logging exceptions to the IPython log file.

The new module is nslsii.common.ipynb.logutils. Should it be in nslsii.common instead?

Also, is there a way to write tests against IPython?