### PR TITLE
create default log directory

### DIFF
--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -273,7 +273,8 @@ def configure_bluesky_logging(ipython, appdirs_appname="bluesky"):
 
     The log file path is taken from environment variable BLUESKY_LOG_FILE, if
     that variable has been set. If not the default log file location is determined
-    by the appdirs package.
+    by the appdirs package. The default log directory will be created if it does
+    not exist.
 
     Parameters
     ----------
@@ -300,14 +301,18 @@ def configure_bluesky_logging(ipython, appdirs_appname="bluesky"):
             file=sys.stderr,
         )
     else:
-        bluesky_log_file_path = Path(
+        bluesky_log_dir = Path(
             appdirs.user_log_dir(appname=appdirs_appname)
-        ) / Path("bluesky.log")
+        )
+        if not bluesky_log_dir.exists():
+            bluesky_log_dir.mkdir(parents=True, exist_ok=True)
+        bluesky_log_file_path = bluesky_log_dir / Path("bluesky.log")
         print(
             f"environment variable BLUESKY_LOG_FILE is not set,"
             f" using default log file path '{bluesky_log_file_path}'",
             file=sys.stderr,
         )
+
     log_file_handler = TimedRotatingFileHandler(
         filename=str(bluesky_log_file_path), when="W0", backupCount=10
     )
@@ -376,9 +381,12 @@ def configure_ipython_logging(
             file=sys.stderr,
         )
     else:
-        bluesky_ipython_log_file_path = Path(
+        bluesky_ipython_log_dir = Path(
             appdirs.user_log_dir(appname=appdirs_appname)
-        ) / Path("bluesky_ipython.log")
+        )
+        if not bluesky_ipython_log_dir.exists():
+            bluesky_ipython_log_dir.mkdir(parents=True, exist_ok=True)
+        bluesky_ipython_log_file_path = bluesky_ipython_log_dir / Path("bluesky_ipython.log")
         print(
             "environment variable BLUESKY_IPYTHON_LOG_FILE is not set,"
             f" using default file path '{bluesky_ipython_log_file_path}'",

--- a/nslsii/tests/test_logutils.py
+++ b/nslsii/tests/test_logutils.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import shutil
 import stat
 from unittest.mock import MagicMock
 
@@ -66,13 +67,9 @@ def test_configure_bluesky_logging_creates_default_dir():
     """
     test_appname = "bluesky-test"
     log_dir = Path(appdirs.user_log_dir(appname=test_appname))
-    # remove log_dir if it exists
-    # make a reasonable effort to delete the log directory
-    # no heroics
+    # remove log_dir if it exists to test that it will be created
     if log_dir.exists():
-        for f in log_dir.iterdir():
-            f.unlink()
-        log_dir.rmdir()
+        shutil.rmtree(path=log_dir)
     log_file_path = log_dir / Path("bluesky.log")
 
     ip = IPython.core.interactiveshell.InteractiveShell()
@@ -133,13 +130,9 @@ def test_ipython_exc_logging_creates_default_dir():
     """
     test_appname = "bluesky-test"
     log_dir = Path(appdirs.user_log_dir(appname=test_appname))
-    # remove log_dir if it exists
-    # make a reasonable effort to delete the log directory
-    # no heroics
+    # remove log_dir if it exists to test that it will be created
     if log_dir.exists():
-        for f in log_dir.iterdir():
-            f.unlink()
-        log_dir.rmdir()
+        shutil.rmtree(path=log_dir)
     log_file_path = log_dir / Path("bluesky_ipython.log")
 
     ip = IPython.core.interactiveshell.InteractiveShell()


### PR DESCRIPTION
Closes #84.

This PR changes the behavior of the two logging configuration functions.
Previously the default log directory would not be created and an exception was raised if it did not exist.
Now if that directory does not exist it will be created.

Existing tests have been updated. New tests have been added.