### PR TITLE
add function to subscribe KafkaPublishers to the RunEngine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,10 @@ matrix:
   include:
     - os: linux
       python: 3.6
-      env: PUBLISH_DOCS=1
     - os: linux
       python: 3.7
-    - os: osx
-      language: generic
-      env: PYTHON=3.6
-    - os: osx
-      language: generic
-      env: PYTHON=3.7
+    - os: linux
+      python: 3.8
     - os: linux
       python: nightly
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,36 @@
 language: python
-python:
-  - 3.6
 
 services:
   - docker
+
+env:
+   global:
+    # Doctr deploy key for NSLS-II/nslsii
+    - secure: "FhNkkbod0Wc/zUf9cTvwziAYHcjfte2POf+hoVSmC+v/RcYKCNCo+mGGMhF9F4KyC2nzvulfzow7YXoswZqav4+TEEu+mpuPaGlf9aqp8V61eij8MVTwonzQEYmHAy3KatwXxyvvhQpfj3gOuDVolfOg2MtNZi6QERES4E1sjOn714fx2HkVxqH2Y8/PF/FzzGeJaRlVaVci0EdIJ5Ss5c5SjO6JGgxj4hzhTPHjTaLjdLHlVhuB9Yatl80zbhGriljLcDQTHmoSODwBpAh5YLDUZq6B9vomaNB9Hb3e0D5gItjOdj53v6AsHU8LkncZMvsgJgh2sZZqMO6nkpHcYPwJgbPbKd3RtVlk6Kg/tvKQk0rMcxl5fFFeD2i9POnANg/xJsKN6yAEY3kaRwQtajQmlcicSa/wdwv9NhUTtBmA/mnyzxHbQXrB0bEc2P2QVu7U8en6dWaOAqc1VCMrWIhp2ADNWb7JZhYj70TgmExIU3UH8qlMb6dyx50SJUE9waJj3fiiZVkjh+E568ZRSMvL9n+bLlFt4uDT4AysSby6cj+zjfNViKFstTAqjyd5VJEvCoUu73vNzWEiWFtEvKKVL1P3pbLN/G3aSSJMa5fc1o+2lRUwdwNNOOdH6iKBDZGNpE8nGDlTP2b2dhFyEt8nICKJhbgU208jhyyH8Vk="
 
 cache:
   directories:
     - $HOME/.cache/pip
     - $HOME/.ccache  # https://github.com/travis-ci/travis-ci/issues/5853
+
+matrix:
+  fast_finish: true
+  include:
+    - os: linux
+      python: 3.6
+      env: PUBLISH_DOCS=1
+    - os: linux
+      python: 3.7
+    - os: osx
+      language: generic
+      env: PYTHON=3.6
+    - os: osx
+      language: generic
+      env: PYTHON=3.7
+    - os: linux
+      python: nightly
+  allow_failures:
+    - python: nightly
 
 before_install:
   - |
@@ -20,11 +42,6 @@ install:
   - pip install .
   # Install extra requirements for running tests and building docs.
   - pip install -r requirements-dev.txt
-
-env:
-   global:
-    # Doctr deploy key for NSLS-II/nslsii
-    - secure: "FhNkkbod0Wc/zUf9cTvwziAYHcjfte2POf+hoVSmC+v/RcYKCNCo+mGGMhF9F4KyC2nzvulfzow7YXoswZqav4+TEEu+mpuPaGlf9aqp8V61eij8MVTwonzQEYmHAy3KatwXxyvvhQpfj3gOuDVolfOg2MtNZi6QERES4E1sjOn714fx2HkVxqH2Y8/PF/FzzGeJaRlVaVci0EdIJ5Ss5c5SjO6JGgxj4hzhTPHjTaLjdLHlVhuB9Yatl80zbhGriljLcDQTHmoSODwBpAh5YLDUZq6B9vomaNB9Hb3e0D5gItjOdj53v6AsHU8LkncZMvsgJgh2sZZqMO6nkpHcYPwJgbPbKd3RtVlk6Kg/tvKQk0rMcxl5fFFeD2i9POnANg/xJsKN6yAEY3kaRwQtajQmlcicSa/wdwv9NhUTtBmA/mnyzxHbQXrB0bEc2P2QVu7U8en6dWaOAqc1VCMrWIhp2ADNWb7JZhYj70TgmExIU3UH8qlMb6dyx50SJUE9waJj3fiiZVkjh+E568ZRSMvL9n+bLlFt4uDT4AysSby6cj+zjfNViKFstTAqjyd5VJEvCoUu73vNzWEiWFtEvKKVL1P3pbLN/G3aSSJMa5fc1o+2lRUwdwNNOOdH6iKBDZGNpE8nGDlTP2b2dhFyEt8nICKJhbgU208jhyyH8Vk="
 
 before_script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
 
 before_script:
   - |
-    sudo docker-compose -f scripts/bitnami-kafka-docker-compose.yml up &
+    sudo docker-compose -f scripts/bitnami-kafka-docker-compose.yml up > kafka_zookeeper.log &
     sleep 20
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,19 @@
 language: python
 python:
   - 3.6
+
+services:
+  - docker
+
 cache:
   directories:
     - $HOME/.cache/pip
     - $HOME/.ccache  # https://github.com/travis-ci/travis-ci/issues/5853
+
+before_install:
+  - |
+    docker --version
+    docker-compose --version
 
 install:
   # Install this package and the packages listed in requirements.txt.
@@ -16,6 +25,11 @@ env:
    global:
     # Doctr deploy key for NSLS-II/nslsii
     - secure: "FhNkkbod0Wc/zUf9cTvwziAYHcjfte2POf+hoVSmC+v/RcYKCNCo+mGGMhF9F4KyC2nzvulfzow7YXoswZqav4+TEEu+mpuPaGlf9aqp8V61eij8MVTwonzQEYmHAy3KatwXxyvvhQpfj3gOuDVolfOg2MtNZi6QERES4E1sjOn714fx2HkVxqH2Y8/PF/FzzGeJaRlVaVci0EdIJ5Ss5c5SjO6JGgxj4hzhTPHjTaLjdLHlVhuB9Yatl80zbhGriljLcDQTHmoSODwBpAh5YLDUZq6B9vomaNB9Hb3e0D5gItjOdj53v6AsHU8LkncZMvsgJgh2sZZqMO6nkpHcYPwJgbPbKd3RtVlk6Kg/tvKQk0rMcxl5fFFeD2i9POnANg/xJsKN6yAEY3kaRwQtajQmlcicSa/wdwv9NhUTtBmA/mnyzxHbQXrB0bEc2P2QVu7U8en6dWaOAqc1VCMrWIhp2ADNWb7JZhYj70TgmExIU3UH8qlMb6dyx50SJUE9waJj3fiiZVkjh+E568ZRSMvL9n+bLlFt4uDT4AysSby6cj+zjfNViKFstTAqjyd5VJEvCoUu73vNzWEiWFtEvKKVL1P3pbLN/G3aSSJMa5fc1o+2lRUwdwNNOOdH6iKBDZGNpE8nGDlTP2b2dhFyEt8nICKJhbgU208jhyyH8Vk="
+
+before_script:
+  - |
+    sudo docker-compose -f scripts/bitnami-kafka-docker-compose.yml up > kafka_zookeeper.log &
+    sleep 20
 
 script:
   - coverage run -m pytest  # Run the tests and check for test coverage.

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 
 before_script:
   - |
-    sudo docker-compose -f scripts/bitnami-kafka-docker-compose.yml up > kafka_zookeeper.log &
+    sudo docker-compose -f scripts/bitnami-kafka-docker-compose.yml up &
     sleep 20
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+dist: bionic
 language: python
+sudo: false
 
 services:
   - docker

--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -43,7 +43,7 @@ def configure_base(
     configure_logging=True,
     pbar=True,
     ipython_logging=True,
-    publish_documents_to_kafka=False
+    publish_documents_to_kafka=False,
 ):
     """
     Perform base setup and instantiation of important objects.
@@ -206,19 +206,14 @@ def configure_base(
         from nslsii.common.ipynb.logutils import log_exception
 
         # IPython logging will be enabled with logstart(...)
-        configure_ipython_logging(
-            exception_logger=log_exception, ipython=get_ipython()
-        )
+        configure_ipython_logging(exception_logger=log_exception, ipython=get_ipython())
 
     if publish_documents_to_kafka:
         subscribe_kafka_publisher(
             RE,
             beamline_name=broker_name,
             bootstrap_servers="cmb01:9092,cmb02:9092,cmb03:9092",
-            producer_config={
-                "enable.idempotence": True,
-                "linger.ms": 0
-            }
+            producer_config={"enable.idempotence": True},
         )
 
     # always configure %xmode minimal
@@ -304,9 +299,7 @@ def configure_bluesky_logging(ipython, appdirs_appname="bluesky"):
             file=sys.stderr,
         )
     else:
-        bluesky_log_dir = Path(
-            appdirs.user_log_dir(appname=appdirs_appname)
-        )
+        bluesky_log_dir = Path(appdirs.user_log_dir(appname=appdirs_appname))
         if not bluesky_log_dir.exists():
             bluesky_log_dir.mkdir(parents=True, exist_ok=True)
         bluesky_log_file_path = bluesky_log_dir / Path("bluesky.log")
@@ -384,12 +377,12 @@ def configure_ipython_logging(
             file=sys.stderr,
         )
     else:
-        bluesky_ipython_log_dir = Path(
-            appdirs.user_log_dir(appname=appdirs_appname)
-        )
+        bluesky_ipython_log_dir = Path(appdirs.user_log_dir(appname=appdirs_appname))
         if not bluesky_ipython_log_dir.exists():
             bluesky_ipython_log_dir.mkdir(parents=True, exist_ok=True)
-        bluesky_ipython_log_file_path = bluesky_ipython_log_dir / Path("bluesky_ipython.log")
+        bluesky_ipython_log_file_path = bluesky_ipython_log_dir / Path(
+            "bluesky_ipython.log"
+        )
         print(
             "environment variable BLUESKY_IPYTHON_LOG_FILE is not set,"
             f" using default file path '{bluesky_ipython_log_file_path}'",
@@ -563,13 +556,15 @@ def subscribe_kafka_publisher(RE, beamline_name, bootstrap_servers, producer_con
             key=start_doc["uid"],
             producer_config=producer_config,
             flush_on_stop_doc=True,
-            serializer=partial(msgpack.dumps, default=mpn.encode)
+            serializer=partial(msgpack.dumps, default=mpn.encode),
         )
 
         return [kafka_publisher], []
 
     rr = RunRouter(factories=[kafka_publisher_factory])
     RE.subscribe(rr)
-    logging.getLogger("nslsii").info('RE will publish documents to Kafka topic %s', topic)
+    logging.getLogger("nslsii").info(
+        "RE will publish documents to Kafka topic %s", topic
+    )
 
     return topic

--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -558,11 +558,12 @@ def subscribe_kafka_publisher(RE, beamline_name, bootstrap_servers, producer_con
     def kafka_publisher_factory(name, start_doc):
         # create a Kafka Publisher for a single run
         kafka_publisher = Publisher(
-             topic=topic,
-             bootstrap_servers=bootstrap_servers,
-             key=start_doc["uid"],
-             producer_config=producer_config,
-             serializer=partial(msgpack.dumps, default=mpn.encode)
+            topic=topic,
+            bootstrap_servers=bootstrap_servers,
+            key=start_doc["uid"],
+            producer_config=producer_config,
+            flush_on_stop_doc=True,
+            serializer=partial(msgpack.dumps, default=mpn.encode)
         )
 
         return [kafka_publisher], []

--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -571,8 +571,12 @@ def subscribe_kafka_publisher(RE, beamline_name, bootstrap_servers, producer_con
         try:
             # call Producer.list_topics to test if we can connect to a Kafka broker
             # TODO: add list_topics method to KafkaPublisher
-            cluster_metadata = kafka_publisher._producer.list_topics(topic=topic, timeout=5.0)
-            logging.getLogger("nslsii").info("connected to Kafka broker(s): %s", cluster_metadata)
+            cluster_metadata = kafka_publisher._producer.list_topics(
+                topic=topic, timeout=5.0
+            )
+            logging.getLogger("nslsii").info(
+                "connected to Kafka broker(s): %s", cluster_metadata
+            )
             return [kafka_publisher], []
         # TODO: raise BlueskyException or similar from KafkaPublisher.list_topics
         except Exception as ke:
@@ -580,7 +584,9 @@ def subscribe_kafka_publisher(RE, beamline_name, bootstrap_servers, producer_con
             # because we are not relying on Kafka. When and if we do rely on Kafka
             # for storing documents we will need a more robust response here.
             nslsii_logger = logging.getLogger("nslsii")
-            nslsii_logger.error("failed to connect to Kafka broker(s) at %s", bootstrap_servers)
+            nslsii_logger.error(
+                "failed to connect to Kafka broker(s) at %s", bootstrap_servers
+            )
             nslsii_logger.exception(ke)
 
             # documents will not be published to Kafka brokers

--- a/nslsii/tests/conftest.py
+++ b/nslsii/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from bluesky.tests.conftest import RE
+import ophyd.sim
+
+
+@pytest.fixture(scope="function")
+def hw(request):
+    return ophyd.sim.hw()

--- a/nslsii/tests/conftest.py
+++ b/nslsii/tests/conftest.py
@@ -1,9 +1,3 @@
-import pytest
-
-from bluesky.tests.conftest import RE
-import ophyd.sim
-
-
-@pytest.fixture(scope="function")
-def hw(request):
-    return ophyd.sim.hw()
+from bluesky.tests.conftest import RE  # noqa
+from bluesky_kafka.tests.conftest import pytest_addoption, bootstrap_servers  # noqa
+from ophyd.tests.conftest import hw  # noqa

--- a/nslsii/tests/test_kafka_publisher.py
+++ b/nslsii/tests/test_kafka_publisher.py
@@ -127,7 +127,7 @@ def test_kafka_publisher(RE, hw, bootstrap_servers):
 
 def test_publisher_with_no_broker(RE, hw):
     # specify a bootstrap server that does not exist
-    kafka_topic = nslsii.subscribe_kafka_publisher(
+    nslsii.subscribe_kafka_publisher(
         RE=RE,
         beamline_name="test",
         bootstrap_servers="100.100.100.100:9092",

--- a/nslsii/tests/test_kafka_publisher.py
+++ b/nslsii/tests/test_kafka_publisher.py
@@ -14,18 +14,18 @@ import nslsii
 
 
 def test_kafka_publisher(RE, hw, bootstrap_servers):
-    topic, runrouter_token = kafka_topic = nslsii.subscribe_kafka_publisher(
+    kafka_topic, runrouter_token = nslsii.subscribe_kafka_publisher(
         RE=RE,
         beamline_name="test",
         bootstrap_servers=bootstrap_servers,
         producer_config={
             "acks": "all",
             "enable.idempotence": False,
-            "request.timeout.ms": 5000,
+            "request.timeout.ms": 1000,
         },
     )
 
-    assert topic == "test.bluesky.documents"
+    assert kafka_topic == "test.bluesky.documents"
     assert isinstance(runrouter_token, int)
 
     # Run a RemoteDispatcher on a separate process. Pass the documents

--- a/nslsii/tests/test_kafka_publisher.py
+++ b/nslsii/tests/test_kafka_publisher.py
@@ -34,7 +34,6 @@ def test_kafka_publisher(RE, hw, bootstrap_servers):
     # is setting a very short "auto.commit.interval.ms" for this test.
     def make_and_start_dispatcher(document_queue):
         def put_in_queue(name, doc):
-            print(f"got a document from Kafka {name} {doc['uid']}")
             document_queue.put((name, doc))
 
         kafka_dispatcher = RemoteDispatcher(
@@ -65,7 +64,6 @@ def test_kafka_publisher(RE, hw, bootstrap_servers):
     # the KafkaPublisher will produce event_pages
     def document_accumulator_factory(start_doc_name, start_doc):
         def document_accumulator(name, doc):
-            print(f"got a document from RunEngine {name} {doc['uid']}")
             local_published_documents.append((name, doc))
 
         return [document_accumulator], []

--- a/nslsii/tests/test_kafka_publisher.py
+++ b/nslsii/tests/test_kafka_publisher.py
@@ -135,7 +135,7 @@ def test_publisher_with_no_broker(RE, hw):
             "acks": "all",
             "enable.idempotence": False,
             "request.timeout.ms": 1000,
-        }
+        },
     )
 
     # use a RunRouter to get event_pages locally because

--- a/nslsii/tests/test_kafka_publisher.py
+++ b/nslsii/tests/test_kafka_publisher.py
@@ -85,7 +85,7 @@ def test_kafka_publisher(RE, hw):
     }
 
     RE(count([hw.det]), md=md)
-    # time.sleep(10)
+    time.sleep(10)
 
     # Get the documents from the queue (or timeout --- test will fail)
     remote_published_documents = []

--- a/nslsii/tests/test_kafka_publisher.py
+++ b/nslsii/tests/test_kafka_publisher.py
@@ -1,0 +1,107 @@
+from functools import partial
+import multiprocessing
+import time
+
+import msgpack
+import msgpack_numpy as mpn
+import numpy as np
+
+from bluesky.plans import count
+from bluesky_kafka import RemoteDispatcher
+from event_model import RunRouter, sanitize_doc
+import nslsii
+
+
+def test_kafka_publisher(RE, hw):
+    beamline_name = "test"
+    kafka_topic = nslsii.subscribe_kafka_publisher(
+        RE=RE,
+        beamline_name=beamline_name,
+        bootstrap_servers="127.0.0.1:9092",
+        producer_config={
+            "acks": "all",
+            "enable.idempotence": False,
+            "request.timeout.ms": 5000,
+            "linger.ms": 0,
+        }
+    )
+
+    # COMPONENT 3
+    # Run a RemoteDispatcher on a separate process. Pass the documents
+    # it receives over a Queue to this process so we can count them for our
+    # test.
+
+    def make_and_start_dispatcher(queue):
+        def put_in_queue(name, doc):
+            queue.put((name, doc))
+
+        kafka_dispatcher = RemoteDispatcher(
+            topics=[kafka_topic],
+            bootstrap_servers="127.0.0.1:9092",
+            group_id="kafka-test-group-id",
+            consumer_config={"auto.offset.reset": "latest"},
+            polling_duration=1.0,
+            deserializer=partial(msgpack.loads, object_hook=mpn.decode),
+        )
+        kafka_dispatcher.subscribe(put_in_queue)
+        kafka_dispatcher.start()
+
+    queue_ = multiprocessing.Queue()
+    dispatcher_proc = multiprocessing.Process(
+        target=make_and_start_dispatcher, daemon=True, args=(queue_,)
+    )
+    dispatcher_proc.start()
+    # give the dispatcher process time to start
+    time.sleep(10)
+
+    local_published_documents = []
+
+    # use a RunRouter to get event_pages locally
+    # since the KafkaPublisher will produce event_pages
+    def local_callback_factory(start_doc_name, start_doc):
+        def local_callback(name, doc):
+            local_published_documents.append((name, doc))
+
+        return [local_callback], []
+
+    local_callback_run_router = RunRouter(factories=[local_callback_factory])
+    RE.subscribe(local_callback_run_router)
+
+    # test that numpy data is transmitted correctly
+    md = {
+        "numpy_data": {"nested": np.array([1, 2, 3])},
+        "numpy_scalar": np.float64(4),
+        "numpy_array": np.ones((3, 3)),
+    }
+
+    RE(count([hw.det]), md=md)
+    # time.sleep(10)
+
+    # test that numpy data is transmitted correctly
+    md = {
+        "numpy_data": {"nested": np.array([4, 5, 6])},
+        "numpy_scalar": np.float64(7),
+        "numpy_array": np.ones((4, 4)),
+    }
+
+    RE(count([hw.det]), md=md)
+    # time.sleep(10)
+
+    # Get the documents from the queue (or timeout --- test will fail)
+    remote_published_documents = []
+    for i in range(len(local_published_documents)):
+        remote_published_documents.append(queue_.get(timeout=2))
+
+    dispatcher_proc.terminate()
+    dispatcher_proc.join()
+
+    # sanitize_doc normalizes some document data, such as numpy arrays, that are
+    # problematic for direct comparison of documents by "assert"
+    sanitized_local_published_documents = [
+        sanitize_doc(doc) for doc in local_published_documents
+    ]
+    sanitized_remote_published_documents = [
+        sanitize_doc(doc) for doc in remote_published_documents
+    ]
+
+    assert sanitized_remote_published_documents == sanitized_local_published_documents

--- a/nslsii/tests/test_kafka_publisher.py
+++ b/nslsii/tests/test_kafka_publisher.py
@@ -120,6 +120,10 @@ def test_kafka_publisher(RE, hw, bootstrap_servers):
     )
     assert sanitized_remote_published_documents == sanitized_local_published_documents
 
+    # test that we got the correct subscription token for the Kafka Publisher
+    # KeyError is raised if the token is not known
+    RE.unsubscribe(token=runrouter_token)
+
 
 def test_publisher_with_no_broker(RE, hw):
     # specify a bootstrap server that does not exist

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = nslsii/tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ databroker
 ipython
 ipywidgets
 matplotlib
+msgpack >=1.0.0
+msgpack-numpy
 numpy
 ophyd
 psutil

--- a/scripts/bitnami-kafka-docker-compose.yml
+++ b/scripts/bitnami-kafka-docker-compose.yml
@@ -1,0 +1,33 @@
+version: '2'
+
+services:
+  zookeeper:
+    image: 'bitnami/zookeeper:3'
+    ports:
+      - '2181:2181'
+    volumes:
+      - 'zookeeper_data:/bitnami'
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+  kafka:
+    image: 'bitnami/kafka:2'
+    ports:
+      - '9092:9092'
+      - '29092:29092'
+    volumes:
+      - 'kafka_data:/bitnami'
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:29092,PLAINTEXT_HOST://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+    depends_on:
+      - zookeeper
+
+volumes:
+  zookeeper_data:
+    driver: local
+  kafka_data:
+    driver: local

--- a/scripts/bitnami-kafka-docker-compose.yml
+++ b/scripts/bitnami-kafka-docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: 'docker.io/bitnami/zookeeper:3-debian-10'
+    image: 'docker.io/bitnami/zookeeper:latest'
     ports:
       - '2181:2181'
     volumes:
@@ -10,7 +10,7 @@ services:
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
   kafka:
-    image: 'docker.io/bitnami/kafka:2-debian-10'
+    image: 'docker.io/bitnami/kafka:latest'
     ports:
       - '9092:9092'
       - '29092:29092'

--- a/scripts/bitnami-kafka-docker-compose.yml
+++ b/scripts/bitnami-kafka-docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: 'bitnami/zookeeper:3'
+    image: 'docker.io/bitnami/zookeeper:3-debian-10'
     ports:
       - '2181:2181'
     volumes:
@@ -10,7 +10,7 @@ services:
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
   kafka:
-    image: 'bitnami/kafka:2'
+    image: 'docker.io/bitnami/kafka:2-debian-10'
     ports:
       - '9092:9092'
       - '29092:29092'


### PR DESCRIPTION
This PR adds a function to subscribe Kafka Publishers to the RunEngine using a RunRouter.

A test for this function is also added which requires a Kafka broker to be running. The broker for testing is set up in the same way as for bluesky-kafka.