### PR TITLE
Add a control to Xspress3Channel to enable/disable ROIs 5 through 16

### DIFF
--- a/nslsii/detectors/xspress3.py
+++ b/nslsii/detectors/xspress3.py
@@ -431,7 +431,8 @@ class Xspress3Channel(ADBase):
 
     rois = DDC(make_rois(range(1, 17)))
     vis_enabled = Cpt(EpicsSignal, 'PluginControlVal')
-
+    extra_rois_enabled = Cpt(EpicsSignal, 'PluginControlValExtraROI')
+    
     def __init__(self, prefix, *, channel_num=None, **kwargs):
         self.channel_num = int(channel_num)
 


### PR DESCRIPTION
This adds an attribute to the Xspress3Channel class to toggle on ROIs 5 through 16.  The IOC seems to disable all ROIs by default. The CSS screen provides controls for enabling these, but save/restore for the standard IOC does not seem to remember this change.  I want to use the high numbered ROIs, so I need access to these PVs when I instantiate an instance of this class.

I think this changes costs very little and provides a sensible interface to a PV to which I need a sensible interface.