### PR TITLE
Fix xspress3 status

### DIFF
--- a/nslsii/detectors/xspress3.py
+++ b/nslsii/detectors/xspress3.py
@@ -619,6 +619,7 @@ class XspressTrigger(BlueskyInterface):
     def unstage(self):
         ret = super().unstage()
         self._acquisition_signal.clear_sub(self._acquire_changed)
+        self._status = None
         return ret
 
     def _acquire_changed(self, value=None, old_value=None, **kwargs):


### PR DESCRIPTION
This is a follow-up PR for the fix we came up with @tacaswell and @bruceravel on a call today. This will eliminate the error message coming from the background thread on the second count of the xspress3 detector object.