### PR TITLE
set propagate = False on loggers

### DIFF
--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -343,24 +343,10 @@ def configure_bluesky_logging(ipython, appdirs_appname="bluesky", propagate_log_
     )
     log_file_handler.setFormatter(logging.Formatter(fmt=log_file_format))
 
-    logging.getLogger("bluesky").addHandler(log_file_handler)
-    logging.getLogger("caproto").addHandler(log_file_handler)
-    logging.getLogger("ophyd").addHandler(log_file_handler)
-    logging.getLogger("nslsii").addHandler(log_file_handler)
-
-    # set the loggers to send INFO and higher log
-    # messages to their handlers
-    logging.getLogger("bluesky").setLevel("INFO")
-    logging.getLogger("caproto").setLevel("INFO")
-    logging.getLogger("ophyd").setLevel("INFO")
-    logging.getLogger("nslsii").setLevel("INFO")
-
-    # configure loggers so that log messages do not
-    # propagate to higher level loggers
-    logging.getLogger("bluesky").propagate = propagate_log_messages
-    logging.getLogger("caproto").propagate = propagate_log_messages
-    logging.getLogger("ophyd").propagate = propagate_log_messages
-    logging.getLogger("nslsii").propagate = propagate_log_messages
+    for logger_name in ("bluesky", "caproto", "ophyd", "nslsii"):
+        logging.getLogger(logger_name).addHandler(log_file_handler)
+        logging.getLogger(logger_name).setLevel("INFO")
+        logging.getLogger(logger_name).propagate = propagate_log_messages
 
     if ipython:
         ipython.log.addHandler(log_file_handler)

--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -280,7 +280,12 @@ def configure_base(
 def configure_bluesky_logging(ipython, appdirs_appname="bluesky"):
     """
     Configure a TimedRotatingFileHandler log handler and attach it to
-    bluesky, ophyd, caproto, and nslsii loggers.
+    bluesky, ophyd, caproto, and nslsii loggers. In addition set the
+    ``propagate`` field on each logger to ``False`` so log messages will
+    not propagate to higher level loggers such as a root logger
+    configured by a user. If you want log messages from these loggers
+    to propagate to higher level loggers simply set the ``propagate``
+    field to ``True`` in client code.
 
     The log file path is taken from environment variable BLUESKY_LOG_FILE, if
     that variable has been set. If not the default log file location is determined
@@ -345,6 +350,14 @@ def configure_bluesky_logging(ipython, appdirs_appname="bluesky"):
     logging.getLogger("nslsii").setLevel("INFO")
     if ipython:
         ipython.log.setLevel("INFO")
+    # configure loggers so that log messages do not
+    # propagate to higher level loggers
+    logging.getLogger("bluesky").propagate = False
+    logging.getLogger("caproto").propagate = False
+    logging.getLogger("ophyd").propagate = False
+    logging.getLogger("nslsii").propagate = False
+    if ipython:
+        ipython.log.propagate = False
 
     return bluesky_log_file_path
 

--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -344,9 +344,10 @@ def configure_bluesky_logging(ipython, appdirs_appname="bluesky", propagate_log_
     log_file_handler.setFormatter(logging.Formatter(fmt=log_file_format))
 
     for logger_name in ("bluesky", "caproto", "ophyd", "nslsii"):
-        logging.getLogger(logger_name).addHandler(log_file_handler)
-        logging.getLogger(logger_name).setLevel("INFO")
-        logging.getLogger(logger_name).propagate = propagate_log_messages
+        logger = logging.getLogger(logger_name)
+        logger.addHandler(log_file_handler)
+        logger.setLevel("INFO")
+        logger.propagate = propagate_log_messages
 
     if ipython:
         ipython.log.addHandler(log_file_handler)

--- a/nslsii/tests/test_logutils.py
+++ b/nslsii/tests/test_logutils.py
@@ -137,12 +137,16 @@ def test_configure_bluesky_logging_propagate_false(tmpdir):
         ipython=ip,
     )
 
-    logging.getLogger("bluesky").info("test_configure_bluesky_logging_propagate_false")
+    logging.getLogger("bluesky").info("bluesky log message")
+    logging.getLogger("caproto").info("caproto log message")
+    logging.getLogger("nslsii").info("nslsii log message")
+    logging.getLogger("ophyd").info("ophyd log message")
+    ip.log.info("ipython log message")
 
     assert bluesky_log_file_path == log_file_path
     assert log_file_path.exists()
 
-    # the log message sent to the bluesky logger should not
+    # the log messages sent above should not
     # propagate to the root logger
     assert len(root_logger_stream.getvalue()) == 0
 
@@ -150,8 +154,8 @@ def test_configure_bluesky_logging_propagate_false(tmpdir):
 def test_configure_bluesky_logging_propagate_true(tmpdir):
     """
     Configure a root logger and set ``propagate=True`` on
-    the bluesky logger. Assert that a log message propagates
-    from the bluesky logger to the root logger.
+    the bluesky loggers. Assert that a log message propagates
+    from the bluesky loggers to the root logger.
     """
     root_logger_stream = io.StringIO()
     logging.getLogger().addHandler(logging.StreamHandler(stream=root_logger_stream))
@@ -162,19 +166,26 @@ def test_configure_bluesky_logging_propagate_true(tmpdir):
     os.environ["BLUESKY_LOG_FILE"] = str(log_file_path)
     bluesky_log_file_path = configure_bluesky_logging(
         ipython=ip,
+        propagate_log_messages=True
     )
 
-    logging.getLogger("bluesky").propagate = True
-    logging.getLogger("bluesky").info("test_configure_bluesky_logging_propagate_true")
+    logging.getLogger("bluesky").info("bluesky log message")
+    logging.getLogger("caproto").info("caproto log message")
+    logging.getLogger("nslsii").info("nslsii log message")
+    logging.getLogger("ophyd").info("ophyd log message")
+    ip.log.info("ipython log message")
 
     assert bluesky_log_file_path == log_file_path
     assert log_file_path.exists()
 
     # the log message sent to the bluesky logger should
     # propagate to the root logger
-    assert root_logger_stream.getvalue().endswith(
-        "test_configure_bluesky_logging_propagate_true\n"
-    )
+    root_logger_output = root_logger_stream.getvalue()
+    assert "bluesky log message" in root_logger_output
+    assert "caproto log message" in root_logger_output
+    assert "nslsii log message" in root_logger_output
+    assert "ophyd log message" in root_logger_output
+    assert "ipython log message" in root_logger_output
 
 
 def test_ipython_log_exception():

--- a/nslsii/tests/test_logutils.py
+++ b/nslsii/tests/test_logutils.py
@@ -1,4 +1,6 @@
+import io
 import os
+import logging
 from pathlib import Path
 import shutil
 import stat
@@ -21,7 +23,9 @@ def test_configure_bluesky_logging(tmpdir):
 
     ip = IPython.core.interactiveshell.InteractiveShell()
     os.environ["BLUESKY_LOG_FILE"] = str(log_file_path)
-    bluesky_log_file_path = configure_bluesky_logging(ipython=ip,)
+    bluesky_log_file_path = configure_bluesky_logging(
+        ipython=ip,
+    )
     assert bluesky_log_file_path == log_file_path
     assert log_file_path.exists()
 
@@ -37,7 +41,9 @@ def test_configure_bluesky_logging_with_nonexisting_dir(tmpdir):
     ip = IPython.core.interactiveshell.InteractiveShell()
     os.environ["BLUESKY_LOG_FILE"] = str(log_file_path)
     with pytest.raises(FileNotFoundError):
-        configure_bluesky_logging(ipython=ip,)
+        configure_bluesky_logging(
+            ipython=ip,
+        )
 
 
 def test_configure_bluesky_logging_with_unwriteable_dir(tmpdir):
@@ -55,7 +61,9 @@ def test_configure_bluesky_logging_with_unwriteable_dir(tmpdir):
     ip = IPython.core.interactiveshell.InteractiveShell()
     os.environ["BLUESKY_LOG_FILE"] = str(log_file_path)
     with pytest.raises(PermissionError):
-        configure_bluesky_logging(ipython=ip,)
+        configure_bluesky_logging(
+            ipython=ip,
+        )
 
 
 def test_configure_bluesky_logging_creates_default_dir():
@@ -111,6 +119,62 @@ def test_configure_bluesky_logging_existing_default_dir():
     # clean up the file and directory this test creates
     bluesky_log_file_path.unlink()
     bluesky_log_file_path.parent.rmdir()
+
+
+def test_configure_bluesky_logging_propagate_false(tmpdir):
+    """
+    Configure a root logger. Assert that a log message does
+    not propagate from the bluesky logger to the root logger.
+    """
+    root_logger_stream = io.StringIO()
+    logging.getLogger().addHandler(logging.StreamHandler(stream=root_logger_stream))
+
+    log_file_path = Path(tmpdir) / Path("bluesky.log")
+
+    ip = IPython.core.interactiveshell.InteractiveShell()
+    os.environ["BLUESKY_LOG_FILE"] = str(log_file_path)
+    bluesky_log_file_path = configure_bluesky_logging(
+        ipython=ip,
+    )
+
+    logging.getLogger("bluesky").info("test_configure_bluesky_logging_propagate_false")
+
+    assert bluesky_log_file_path == log_file_path
+    assert log_file_path.exists()
+
+    # the log message sent to the bluesky logger should not
+    # propagate to the root logger
+    assert len(root_logger_stream.getvalue()) == 0
+
+
+def test_configure_bluesky_logging_propagate_true(tmpdir):
+    """
+    Configure a root logger and set ``propagate=True`` on
+    the bluesky logger. Assert that a log message propagates
+    from the bluesky logger to the root logger.
+    """
+    root_logger_stream = io.StringIO()
+    logging.getLogger().addHandler(logging.StreamHandler(stream=root_logger_stream))
+
+    log_file_path = Path(tmpdir) / Path("bluesky.log")
+
+    ip = IPython.core.interactiveshell.InteractiveShell()
+    os.environ["BLUESKY_LOG_FILE"] = str(log_file_path)
+    bluesky_log_file_path = configure_bluesky_logging(
+        ipython=ip,
+    )
+
+    logging.getLogger("bluesky").propagate = True
+    logging.getLogger("bluesky").info("test_configure_bluesky_logging_propagate_true")
+
+    assert bluesky_log_file_path == log_file_path
+    assert log_file_path.exists()
+
+    # the log message sent to the bluesky logger should
+    # propagate to the root logger
+    assert root_logger_stream.getvalue().endswith(
+        "test_configure_bluesky_logging_propagate_true\n"
+    )
 
 
 def test_ipython_log_exception():
@@ -180,7 +244,8 @@ def test_configure_ipython_exc_logging(tmpdir):
     ip = IPython.core.interactiveshell.InteractiveShell()
     os.environ["BLUESKY_IPYTHON_LOG_FILE"] = str(log_file_path)
     bluesky_ipython_log_file_path = configure_ipython_logging(
-        exception_logger=log_exception, ipython=ip,
+        exception_logger=log_exception,
+        ipython=ip,
     )
     assert bluesky_ipython_log_file_path == log_file_path
     assert log_file_path.exists()
@@ -194,7 +259,8 @@ def test_configure_ipython_exc_logging_with_nonexisting_dir(tmpdir):
     os.environ["BLUESKY_IPYTHON_LOG_FILE"] = str(log_file_path)
     with pytest.raises(UserWarning):
         configure_ipython_logging(
-            exception_logger=log_exception, ipython=ip,
+            exception_logger=log_exception,
+            ipython=ip,
         )
 
 
@@ -208,7 +274,8 @@ def test_configure_ipython_exc_logging_with_unwriteable_dir(tmpdir):
     os.environ["BLUESKY_IPYTHON_LOG_FILE"] = str(log_file_path)
     with pytest.raises(PermissionError):
         configure_ipython_logging(
-            exception_logger=log_exception, ipython=ip,
+            exception_logger=log_exception,
+            ipython=ip,
         )
 
 
@@ -221,7 +288,8 @@ def test_configure_ipython_exc_logging_file_exists(tmpdir):
     ip = IPython.core.interactiveshell.InteractiveShell()
     os.environ["BLUESKY_IPYTHON_LOG_FILE"] = str(log_file_path)
     bluesky_ipython_log_file_path = configure_ipython_logging(
-        exception_logger=log_exception, ipython=ip,
+        exception_logger=log_exception,
+        ipython=ip,
     )
     assert bluesky_ipython_log_file_path == log_file_path
     assert log_file_path.exists()


### PR DESCRIPTION
This PR proposes a solution to the problem of users being overwhelmed with log output from the loggers configured in `nslsii.configure_base` when they configure their own root logger.

By setting `getLogger(["bluesky", "caproto", "ophyd", "nslsii"]).propagate = False`, log messages sent to those loggers will not propagate to higher-level loggers such as a root logger. This will allow our logging to proceed without disturbing users who configure a root logger to print their log messages to the console.

The documentation for `nslsii.configure_bluesky_logging` has been updated to reflect this change and to direct users to set `getLogger(...).propagate = True` in their code if they want log messages to propagate from our loggers to higher-level loggers.