### PR TITLE
FIX: be forgiving of type instability in TwoButtonShutter status PV

### DIFF
--- a/nslsii/devices.py
+++ b/nslsii/devices.py
@@ -51,7 +51,7 @@ class TwoButtonShutter(Device):
         def shutter_cb(value, timestamp, **kwargs):
             try:
                 value = enums[int(value)]
-            except ValueError:
+            except (ValueError, TypeError):
                 # we are here because value is a str not int
                 # just move on
                 ...
@@ -67,7 +67,7 @@ class TwoButtonShutter(Device):
             nonlocal count
             try:
                 value = cmd_enums[int(value)]
-            except ValueError:
+            except (ValueError, TypeError):
                 # we are here because value is a str not int
                 # just move on
                 ...

--- a/nslsii/devices.py
+++ b/nslsii/devices.py
@@ -97,7 +97,7 @@ class TwoButtonShutter(Device):
 
         return st
 
-    def stop(self, success):
+    def stop(self, *, success=False):
         import time
         prev_st = self._set_st
         if prev_st is not None:

--- a/nslsii/devices.py
+++ b/nslsii/devices.py
@@ -49,7 +49,12 @@ class TwoButtonShutter(Device):
         enums = self.status.enum_strs
 
         def shutter_cb(value, timestamp, **kwargs):
-            value = enums[int(value)]
+            try:
+                value = enums[int(value)]
+            except ValueError:
+                # we are here because value is a str not int
+                # just move on
+                ...
             if value == target_val:
                 self._set_st = None
                 self.status.clear_sub(shutter_cb)
@@ -60,7 +65,12 @@ class TwoButtonShutter(Device):
 
         def cmd_retry_cb(value, timestamp, **kwargs):
             nonlocal count
-            value = cmd_enums[int(value)]
+            try:
+                value = cmd_enums[int(value)]
+            except ValueError:
+                # we are here because value is a str not int
+                # just move on
+                ...
             count += 1
             if count > self.MAX_ATTEMPTS:
                 cmd_sig.clear_sub(cmd_retry_cb)


### PR DESCRIPTION
# This needs to be on floor at every beamline by noon tomorrow.

------

https://github.com/bluesky/ophyd/pull/946 changed it so that the value
passed to the callabck is the str version of the value not the
integer.

This means that the conversion of int -> str we are doing in the
callbacks of TwoButtonShutter are redundant and failing.  This means
that we will not ever mark the status object as done (and tend to fail
with a miss leading error due to trying to set the shutter again on
the way out of the RE).


This is a modified version of https://github.com/NSLS-II-ISS/profile_collection/pull/6 which is reportedly working at ISS