### PR TITLE
Publish kafka messages from a thread

### DIFF
--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -216,7 +216,7 @@ def configure_base(
         configure_ipython_logging(exception_logger=log_exception, ipython=ipython)
 
     if publish_documents_to_kafka:
-        subscribe_kafka_publisher(
+        _build_and_subscribe_kafka_publisher(
             RE,
             beamline_name=broker_name,
             bootstrap_servers=os.environ['BLUESKY_KAFKA_BOOTSTRAP_SERVERS'],
@@ -547,7 +547,7 @@ def migrate_metadata():
     new_md.update(old_md)
 
 
-def subscribe_kafka_publisher(RE, publisher_queue, kafka_publisher):
+def _subscribe_kafka_publisher(RE, publisher_queue, kafka_publisher):
     """
     Define functions to put (name, document) tuples on the publisher_queue and
     take them off.
@@ -652,7 +652,7 @@ def subscribe_kafka_publisher(RE, publisher_queue, kafka_publisher):
     return kafka_publisher_re_token, kafka_publisher_thread, kafka_publisher_thread_stop_event
 
 
-def build_and_subscribe_kafka_publisher(RE, beamline_name, bootstrap_servers, producer_config):
+def _build_and_subscribe_kafka_publisher(RE, beamline_name, bootstrap_servers, producer_config):
     """
     Create and start a separate thread to publish bluesky documents as Kafka
     messages on a beamline-specific topic.
@@ -707,7 +707,7 @@ def build_and_subscribe_kafka_publisher(RE, beamline_name, bootstrap_servers, pr
                 producer_config=producer_config,
                 flush_on_stop_doc=True
             )
-            kafka_publisher_token, kafka_publisher_thread, kafka_publisher_thread_stop_event = subscribe_kafka_publisher(
+            kafka_publisher_token, kafka_publisher_thread, kafka_publisher_thread_stop_event = _subscribe_kafka_publisher(
                 RE=RE,
                 publisher_queue=publisher_queue,
                 kafka_publisher=kafka_publisher

--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -547,24 +547,36 @@ def migrate_metadata():
     new_md.update(old_md)
 
 
-def _subscribe_kafka_publisher(RE, publisher_queue, kafka_publisher):
+def _subscribe_kafka_publisher(RE, publisher_queue, kafka_publisher, publisher_queue_timeout=1):
     """
-    Define functions to put (name, document) tuples on the publisher_queue and
-    take them off.
+    Set up an indirect connection between RE and Kafka publisher using a queue and a thread.
+
+    The function performs two tasks:
+    1) define function put_document_on_publisher_queue and subscribe it to the RE
+    2) define function publish_documents_from_publisher_queue and run it in a thread
+
+    This function is not intended for use outside this module.
 
     Parameters
     ----------
     RE: bluesky RunEngine
-
+        documents published by this RE will be published as Kafka messages
     publisher_queue: queue.Queue
         a RunEngine will place (name, document) tuples on this queue
-
     kafka_publisher:  bluesky_kafka.Publisher
         publishes (name, document) tuples as Kafka messages on a beamline-specific topic
+    publisher_queue_timeout: float
+        time in seconds to wait for a document to become available on the publisher_queue
+        before checking if the publisher thread should terminate; default is 1s
 
     Returns
     -------
-    kafka_publisher_re_token, kafka_publisher_thread, kafka_publisher_thread_stop_event
+    put_document_re_token
+        RE subscription token corresponding to put_document_on_publisher_queue
+    publisher_thread
+        threading.Thread responsible for running function publishe_documents_from_publisher_queue
+    publisher_thread_stop_event
+        call set() on this threading.Event to terminate publisher_thread
 
     """
     def put_document_on_publisher_queue(name_, document_):
@@ -588,10 +600,11 @@ def _subscribe_kafka_publisher(RE, publisher_queue, kafka_publisher):
     def publish_documents_from_publisher_queue(
             publisher_queue_,
             kafka_publisher_,
-            kafka_publisher_thread_stop_event_
+            publisher_thread_stop_event_,
+            publisher_queue_timeout_=1,
     ):
         """
-        This function is intended to execute in a dedicated thread. It runs
+        This function is intended to execute in a dedicated thread. It defines
         a polling loop that takes (name, document) tuples from publisher_queue_
         as they become available and uses kafka_publisher_ to publish those
         tuples as Kafka messages on a beamline-specific topic.
@@ -606,29 +619,31 @@ def _subscribe_kafka_publisher(RE, publisher_queue, kafka_publisher):
             a RunEngine will place (name, document) tuples on this queue
         kafka_publisher_:  bluesky_kafka.Publisher
             publishes (name, document) tuples as Kafka messages on a beamline-specific topic
-        kafka_publisher_thread_stop_event_: threading.Event
+        publisher_thread_stop_event_: threading.Event
             the polling loop will terminate cleanly if kafka_publisher_thread_stop_event_ is set
+        publisher_queue_timeout_: float
+            time in seconds to wait for a document to become available on the publisher_queue_
+            before checking if kafka_publisher_thread_stop_event_ has been set
         """
         name_ = None
         document_ = None
         published_document_count = 0
         nslsii_logger = logging.getLogger("nslsii")
         nslsii_logger.info("starting Kafka message publishing loop")
-        while not kafka_publisher_thread_stop_event_.is_set():
+        while not publisher_thread_stop_event_.is_set():
             try:
-                # specify a timeout so kafka_publisher_thread_stop_event
-                # will be checked regularly
-                name_, document_ = publisher_queue_.get(timeout=1)
+                name_, document_ = publisher_queue_.get(timeout=publisher_queue_timeout_)
                 kafka_publisher_(name_, document_)
                 published_document_count += 1
             except queue.Empty:
                 # publisher_queue_.get() timed out waiting for a new document
-                # the while condition will be checked now to see if someone
+                # the while condition will now be checked to see if someone
                 # has requested that this thread terminate
-                # if not then try to get a new document
+                # if not then try again to get a new document from publisher_queue_
                 pass
             except BaseException:
                 # something bad happened while trying to publish a Kafka message
+                # log the exception and continue taking documents from publisher_queue_
                 nslsii_logger.exception(
                     "an error occurred after %d successful Kafka messages when '%s' "
                     "attempted to publish on topic %s\nname: '%s'\ndoc '%s'",
@@ -639,27 +654,29 @@ def _subscribe_kafka_publisher(RE, publisher_queue, kafka_publisher):
                     document_,
                 )
 
-    kafka_publisher_thread_stop_event = threading.Event()
-    kafka_publisher_thread = threading.Thread(
+    publisher_thread_stop_event = threading.Event()
+    publisher_thread = threading.Thread(
         name="kafka-publisher-thread",
         target=publish_documents_from_publisher_queue,
-        args=(publisher_queue, kafka_publisher, kafka_publisher_thread_stop_event),
+        args=(publisher_queue, kafka_publisher, publisher_thread_stop_event, publisher_queue_timeout),
         daemon=True
     )
-    kafka_publisher_thread.start()
+    publisher_thread.start()
     nslsii_logger = logging.getLogger("nslsii")
     nslsii_logger.info("Kafka publisher thread has started")
-    kafka_publisher_re_token = RE.subscribe(put_document_on_publisher_queue)
-    return kafka_publisher_re_token, kafka_publisher_thread, kafka_publisher_thread_stop_event
+    put_document_re_token = RE.subscribe(put_document_on_publisher_queue)
+    return put_document_re_token, publisher_thread, publisher_thread_stop_event
 
 
-def _build_and_subscribe_kafka_publisher(RE, beamline_name, bootstrap_servers, producer_config):
+def _build_and_subscribe_kafka_publisher(RE, beamline_name, bootstrap_servers, producer_config, publisher_queue_timeout=1):
     """
     Create and start a separate thread to publish bluesky documents as Kafka
     messages on a beamline-specific topic.
 
-    bluesky documents are put on a queue.Queue by the RunEngine and taken off
-    the queue.Queue in the new thread to be published by a bluesky_kafka.Publisher.
+    This function performs three tasks:
+      1) verify a Kafka broker with the expected beamline-specific topic is available
+      2) instantiate a bluesky_kafka.Publisher with the expected beamline-specific topic
+      3) delegate connecting the RunEngine and Publisher to _subscribe_kafka_publisher
 
     Parameters
     ----------
@@ -690,7 +707,7 @@ def _build_and_subscribe_kafka_publisher(RE, beamline_name, bootstrap_servers, p
     publisher_queue = queue.Queue()
     beamline_runengine_topic = None
     kafka_publisher_token = None
-    kafka_publisher_thread_stop_event = None
+    publisher_thread_stop_event = None
 
     try:
         nslsii_logger.info(
@@ -708,10 +725,11 @@ def _build_and_subscribe_kafka_publisher(RE, beamline_name, bootstrap_servers, p
                 producer_config=producer_config,
                 flush_on_stop_doc=True
             )
-            kafka_publisher_token, kafka_publisher_thread, kafka_publisher_thread_stop_event = _subscribe_kafka_publisher(
+            kafka_publisher_token, kafka_publisher_thread, publisher_thread_stop_event = _subscribe_kafka_publisher(
                 RE=RE,
                 publisher_queue=publisher_queue,
-                kafka_publisher=kafka_publisher
+                kafka_publisher=kafka_publisher,
+                publisher_queue_timeout=publisher_queue_timeout
             )
             nslsii_logger.info("RunEngine will publish bluesky documents on Kafka topic '%s'", beamline_runengine_topic)
         else:
@@ -728,4 +746,4 @@ def _build_and_subscribe_kafka_publisher(RE, beamline_name, bootstrap_servers, p
             beamline_runengine_topic
         )
 
-    return beamline_runengine_topic, kafka_publisher_thread_stop_event, kafka_publisher_token
+    return beamline_runengine_topic, publisher_thread_stop_event, kafka_publisher_token

--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -625,6 +625,7 @@ def _subscribe_kafka_publisher(RE, publisher_queue, kafka_publisher):
                 # publisher_queue_.get() timed out waiting for a new document
                 # the while condition will be checked now to see if someone
                 # has requested that this thread terminate
+                # if not then try to get a new document
                 pass
             except BaseException:
                 # something bad happened while trying to publish a Kafka message

--- a/nslsii/tests/conftest.py
+++ b/nslsii/tests/conftest.py
@@ -1,3 +1,73 @@
+from contextlib import contextmanager
+import pytest
 from bluesky.tests.conftest import RE  # noqa
-from bluesky_kafka.tests.conftest import pytest_addoption, kafka_bootstrap_servers  # noqa
+from bluesky_kafka import BlueskyConsumer
+from bluesky_kafka.tests.conftest import (
+    pytest_addoption,
+    kafka_bootstrap_servers,
+    temporary_topics,
+)  # noqa
 from ophyd.tests.conftest import hw  # noqa
+
+
+# this should move to bluesky_kafka
+@pytest.fixture(scope="function")
+def consume_documents_from_kafka_until_first_stop_document(request, kafka_bootstrap_servers):
+
+    def _consume_documents_from_kafka(kafka_topic, bootstrap_servers=None):
+        if bootstrap_servers is None:
+            bootstrap_servers = kafka_bootstrap_servers
+
+        consumed_bluesky_documents = []
+
+        def store_consumed_document(consumer, topic, name, document):
+            """
+            This function keeps a list of all documents the consumer
+            gets from the Kafka broker(s).
+
+            Parameters
+            ----------
+            consumer: bluesky_kafka.BlueskyConsumer
+                unused
+            topic: str
+                unused
+            name: str
+                bluesky document name, such as "start", "descriptor", "event", etc
+            document: dict
+                dictionary of bluesky document data
+            """
+            consumed_bluesky_documents.append((name, document))
+
+        bluesky_consumer = BlueskyConsumer(
+            topics=[kafka_topic],
+            bootstrap_servers=bootstrap_servers,
+            group_id=f"{kafka_topic}.consumer.group",
+            consumer_config={
+                # this consumer is intended to read messages that
+                # have already been published, so it is necessary
+                # to specify "earliest" here
+                "auto.offset.reset": "earliest",
+            },
+            process_document=store_consumed_document,
+            polling_duration=1.0,
+        )
+
+        def until_first_stop_document():
+            """
+            This function returns False to end the BlueskyConsumer polling loop after seeing
+            a "stop" document. This is important for the test to end.
+            """
+            if "stop" in [name for name, _ in consumed_bluesky_documents]:
+                return False
+            else:
+                return True
+
+        # start() will return when 'until_first_stop_document' returns False
+        bluesky_consumer.start(
+            continue_polling=until_first_stop_document,
+        )
+        # how do we get here?
+
+        return consumed_bluesky_documents
+
+    return _consume_documents_from_kafka

--- a/nslsii/tests/test_kafka_publisher_thread.py
+++ b/nslsii/tests/test_kafka_publisher_thread.py
@@ -166,9 +166,12 @@ def test_subscribe_kafka_publisher(temporary_topics, RE):
     """
     Test exception handling when a bluesky_kafka.Publisher raises an exception.
 
-    Parameter
-    ---------
-    RE: RunEngine
+    Parameters
+    ----------
+    temporary_topics: context manager (pytest fixture)
+        creates and cleans up temporary Kafka topics for testing
+    RE: pytest fixture
+        bluesky RunEngine
 
     """
     # use a random string as the beamline name so topics will not be duplicated across tests

--- a/nslsii/tests/test_kafka_publisher_thread.py
+++ b/nslsii/tests/test_kafka_publisher_thread.py
@@ -26,6 +26,14 @@ def test_build_and_subscribe_kafka_publisher(
     Start Kafka and Zookeeper like this:
       $ sudo docker-compose -f scripts/bitnami-kafka-docker-compose.yml up
 
+    If Kafka fails to start it may be necessary to delete this log file:
+      $ sudo ls -la /var/lib/docker/volumes/scripts_zookeeper_data/_data/zookeeper/data/version-2/
+      total 20
+      drwxr-xr-x 2 1001 root     4096 Jul 14 13:37 .
+      drwxrwxr-x 3 root root     4096 Jul 14 13:37 ..
+      -rw-r--r-- 1 1001 root 67108880 Jul 14 13:37 log.1          <----
+      -rw-r--r-- 1 1001 root      457 Jul 14 13:37 snapshot.0
+
     Remove Kafka and Zookeeper containers like this:
       $ sudo docker ps -a -q
       78485383ca6f
@@ -40,7 +48,7 @@ def test_build_and_subscribe_kafka_publisher(
     Or remove ALL containers like this:
       $ sudo docker stop $(sudo docker ps -a -q)
       $ sudo docker rm $(sudo docker ps -a -q)
-    Use this in difficult cases:
+    Use this in difficult cases to remove *all traces* of docker containers:
       $ sudo docker system prune -a
 
     Parameters

--- a/nslsii/tests/test_kafka_publisher_thread.py
+++ b/nslsii/tests/test_kafka_publisher_thread.py
@@ -65,7 +65,7 @@ def test_build_and_subscribe_kafka_publisher(
             nslsii_beamline_topic,
             kafka_publisher_thread_exit_event,
             subscription_token,
-        ) = nslsii.build_and_subscribe_kafka_publisher(
+        ) = nslsii._build_and_subscribe_kafka_publisher(
             RE=RE,
             beamline_name=beamline_name,
             bootstrap_servers=kafka_bootstrap_servers,
@@ -142,7 +142,7 @@ def test_no_beamline_topic(kafka_bootstrap_servers, RE):
 
         # use a random string as the beamline name so topics will not be duplicated across tests
         beamline_name = str(uuid.uuid4())[:8]
-        nslsii.build_and_subscribe_kafka_publisher(
+        nslsii._build_and_subscribe_kafka_publisher(
             RE=RE,
             beamline_name=beamline_name,
             bootstrap_servers=kafka_bootstrap_servers,
@@ -195,7 +195,7 @@ def test_subscribe_kafka_publisher(temporary_topics, RE):
             _,
             kafka_publisher_thread,
             kafka_publisher_thread_stop_event,
-        ) = nslsii.subscribe_kafka_publisher(
+        ) = nslsii._subscribe_kafka_publisher(
             RE=RE, publisher_queue=publisher_queue, kafka_publisher=mock_kafka_publisher
         )
 

--- a/nslsii/tests/test_kafka_publisher_thread.py
+++ b/nslsii/tests/test_kafka_publisher_thread.py
@@ -8,26 +8,6 @@ from event_model import sanitize_doc
 import nslsii
 
 
-def configure_debug_logging(logger_name):
-    # create logger
-    logger_ = logging.getLogger(logger_name)
-    logger_.setLevel(logging.DEBUG)
-    # create console handler and set level to debug
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.DEBUG)
-    # create formatter
-    formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    )
-    # add formatter to ch
-    ch.setFormatter(formatter)
-    # add ch to logger
-    logger_.addHandler(ch)
-
-
-configure_debug_logging("nslsii")
-
-
 def test_build_and_subscribe_kafka_publisher(
     kafka_bootstrap_servers,
     temporary_topics,

--- a/nslsii/tests/test_kafka_publisher_thread.py
+++ b/nslsii/tests/test_kafka_publisher_thread.py
@@ -1,0 +1,251 @@
+import io
+import logging
+import re
+import uuid
+
+from bluesky.plans import count
+from event_model import sanitize_doc
+import nslsii
+
+
+def configure_debug_logging(logger_name):
+    # create logger
+    logger_ = logging.getLogger(logger_name)
+    logger_.setLevel(logging.DEBUG)
+    # create console handler and set level to debug
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.DEBUG)
+    # create formatter
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    # add formatter to ch
+    ch.setFormatter(formatter)
+    # add ch to logger
+    logger_.addHandler(ch)
+
+
+configure_debug_logging("nslsii")
+
+
+def test_build_and_subscribe_kafka_publisher(
+    kafka_bootstrap_servers,
+    temporary_topics,
+    consume_documents_from_kafka_until_first_stop_document,
+    RE,
+    hw,
+):
+    """Test threaded publishing of Kafka messages.
+
+    This test follows the pattern in bluesky_kafka/tests/test_in_single_process.py,
+    which is to publish Kafka messages _before_ subscribing a Kafka consumer to
+    those messages. After the messages have been published a consumer is subscribed
+    to the topic and should receive all messages since they will have been cached by
+    the Kafka broker(s). This keeps the test code relatively simple.
+
+    Start Kafka and Zookeeper like this:
+      $ sudo docker-compose -f scripts/bitnami-kafka-docker-compose.yml up
+
+    Remove Kafka and Zookeeper containers like this:
+      $ sudo docker ps -a -q
+      78485383ca6f
+      8a80fb4a385f
+      $ sudo docker stop 78485383ca6f 8a80fb4a385f
+      78485383ca6f
+      8a80fb4a385f
+      $ sudo docker rm 78485383ca6f 8a80fb4a385f
+      78485383ca6f
+      8a80fb4a385f
+
+    Or remove ALL containers like this:
+      $ sudo docker stop $(sudo docker ps -a -q)
+      $ sudo docker rm $(sudo docker ps -a -q)
+    Use this in difficult cases:
+      $ sudo docker system prune -a
+
+    Parameters
+    ----------
+    kafka_bootstrap_servers: str (pytest fixture)
+        comma-delimited string of Kafka broker host:port, for example "kafka1:9092,kafka2:9092"
+    temporary_topics: context manager (pytest fixture)
+        creates and cleans up temporary Kafka topics for testing
+    RE: pytest fixture
+        bluesky RunEngine
+    hw: pytest fixture
+        ophyd simulated hardware objects
+    """
+
+    # use a random string as the beamline name so topics will not be duplicated across tests
+    beamline_name = str(uuid.uuid4())[:8]
+    with temporary_topics(topics=[f"{beamline_name}.bluesky.runengine.documents"]) as (
+        beamline_topic,
+    ):
+
+        (
+            nslsii_beamline_topic,
+            subscription_token,
+        ) = nslsii.build_and_subscribe_kafka_publisher(
+            RE=RE,
+            beamline_name=beamline_name,
+            bootstrap_servers=kafka_bootstrap_servers,
+            producer_config={
+                "acks": "all",
+                "enable.idempotence": False,
+                "request.timeout.ms": 1000,
+            },
+        )
+
+        assert nslsii_beamline_topic == beamline_topic
+        assert isinstance(subscription_token, int)
+
+        published_bluesky_documents = []
+
+        # this function will store all documents
+        # published by the RunEngine in a list
+        def store_published_document(name, document):
+            published_bluesky_documents.append((name, document))
+
+        RE.subscribe(store_published_document)
+
+        RE(count([hw.det]))
+
+        # it is known that RE(count()) will produce four
+        # documents: start, descriptor, event, stop
+        assert len(published_bluesky_documents) == 4
+
+        consumed_bluesky_documents = (
+            consume_documents_from_kafka_until_first_stop_document(
+                kafka_topic=nslsii_beamline_topic
+            )
+        )
+
+        assert len(published_bluesky_documents) == len(consumed_bluesky_documents)
+
+        # sanitize_doc normalizes some document data, such as numpy arrays, that are
+        # problematic for direct comparison of documents by 'assert'
+        sanitized_published_bluesky_documents = [
+            sanitize_doc(doc) for doc in published_bluesky_documents
+        ]
+        sanitized_consumed_bluesky_documents = [
+            sanitize_doc(doc) for doc in consumed_bluesky_documents
+        ]
+
+        assert len(sanitized_consumed_bluesky_documents) == len(
+            sanitized_published_bluesky_documents
+        )
+        assert (
+            sanitized_consumed_bluesky_documents
+            == sanitized_published_bluesky_documents
+        )
+
+
+def test_no_beamline_topic(kafka_bootstrap_servers, RE):
+    """
+    If the beamline Kafka topic does not exist then an exception
+    should be raised and handled by writing an exception message
+    to the nslsii logger.
+
+    Parameters
+    ----------
+    kafka_bootstrap_servers: str (pytest fixture)
+        comma-delimited string of Kafka broker host:port, for example "kafka1:9092,kafka2:9092"
+    RE: RunEngine (pytest fixture)
+        bluesky RunEngine
+    """
+    try:
+        logging_test_output = io.StringIO()
+        nslsii_logger = logging.getLogger("nslsii")
+        logging_test_handler = logging.StreamHandler(stream=logging_test_output)
+        logging_test_handler.setFormatter(logging.Formatter("%(message)s"))
+        nslsii_logger.addHandler(logging_test_handler)
+
+        # use a random string as the beamline name so topics will not be duplicated across tests
+        beamline_name = str(uuid.uuid4())[:8]
+        nslsii.build_and_subscribe_kafka_publisher(
+            RE=RE,
+            beamline_name=beamline_name,
+            bootstrap_servers=kafka_bootstrap_servers,
+            producer_config={
+                "acks": "all",
+                "enable.idempotence": False,
+                "request.timeout.ms": 1000,
+            },
+        )
+
+        assert (
+            f"topic `{beamline_name}.bluesky.runengine.documents` does not exist on Kafka broker(s)"
+            in logging_test_output.getvalue()
+        )
+
+    finally:
+        nslsii_logger.removeHandler(hdlr=logging_test_handler)
+
+
+def test_subscribe_kafka_publisher(temporary_topics, RE):
+    """
+    Test exception handling when a bluesky_kafka.Publisher raises an exception.
+
+    Parameter
+    ---------
+    RE: RunEngine
+
+    """
+    # use a random string as the beamline name so topics will not be duplicated across tests
+    beamline_name = str(uuid.uuid4())[:8]
+    with temporary_topics(topics=[f"{beamline_name}.bluesky.runengine.documents"]) as (
+        beamline_topic,
+    ):
+        import time
+        import queue
+        from unittest.mock import Mock
+        from bluesky_kafka import BlueskyKafkaException
+
+        logging_test_output = io.StringIO()
+        nslsii_logger = logging.getLogger("nslsii")
+        logging_test_handler = logging.StreamHandler(stream=logging_test_output)
+        logging_test_handler.setFormatter(
+            logging.Formatter("%(threadName)s - %(message)s")
+        )
+        nslsii_logger.addHandler(logging_test_handler)
+
+        publisher_queue = queue.Queue()
+        mock_kafka_publisher = Mock(side_effect=BlueskyKafkaException())
+        (
+            _,
+            kafka_publisher_thread,
+            kafka_publisher_thread_stop_event,
+        ) = nslsii.subscribe_kafka_publisher(
+            RE=RE, publisher_queue=publisher_queue, kafka_publisher=mock_kafka_publisher
+        )
+
+        # provoke two exceptions
+        publisher_queue.put(("blarg", {}))
+        publisher_queue.put(("barf", {}))
+
+        while not publisher_queue.empty():
+            time.sleep(1)
+            print("ha!")
+        print("done!")
+
+        kafka_publisher_thread_stop_event.set()
+        kafka_publisher_thread.join()
+
+        log_output = logging_test_output.getvalue()
+        print("****************")
+        print(log_output)
+        print("****************")
+        exception_message_pattern = re.compile(
+            r"an error occurred after 0 successful Kafka messages when '<Mock id='\d+'>' attempted to publish",
+        )
+
+        first_match = exception_message_pattern.search(log_output)
+        assert first_match
+
+        print(f"log_output[{first_match.endpos}:]: {log_output[first_match.endpos:]}")
+        second_match = exception_message_pattern.search(
+            log_output, pos=first_match.endpos
+        )
+        assert second_match
+
+        # third_match = exception_message_pattern.search(log_output, pos=second_match.endpos)
+        # assert third_match is None

--- a/nslsii/tests/test_kafka_publisher_thread.py
+++ b/nslsii/tests/test_kafka_publisher_thread.py
@@ -26,14 +26,6 @@ def test_build_and_subscribe_kafka_publisher(
     Start Kafka and Zookeeper like this:
       $ sudo docker-compose -f scripts/bitnami-kafka-docker-compose.yml up
 
-    If Kafka fails to start it may be necessary to delete this log file:
-      $ sudo ls -la /var/lib/docker/volumes/scripts_zookeeper_data/_data/zookeeper/data/version-2/
-      total 20
-      drwxr-xr-x 2 1001 root     4096 Jul 14 13:37 .
-      drwxrwxr-x 3 root root     4096 Jul 14 13:37 ..
-      -rw-r--r-- 1 1001 root 67108880 Jul 14 13:37 log.1          <----
-      -rw-r--r-- 1 1001 root      457 Jul 14 13:37 snapshot.0
-
     Remove Kafka and Zookeeper containers like this:
       $ sudo docker ps -a -q
       78485383ca6f


### PR DESCRIPTION
This PR modifies the function that subscribes a Kafka Publisher to the RunEngine by inserting a thread between the two. The RunEngine places documents in a queue, and the "publishing thread" takes those documents off the queue and publishes them. The intention is to insulate plans from Kafka exceptions using the same idea as is used for olog.

Significant improvements have been made to the test coverage.