### PR TITLE
CI: add a workflow to publish on PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,5 +1,6 @@
-# This workflows will upload a Python Package using flit when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# This workflow will upload a Python Package using flit when a release is
+# created.  For more information see:
+# https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Upload Python Package
 
@@ -27,7 +28,7 @@ jobs:
         TWINE_USERNAME: __token__
         # The PYPI_PASSWORD must be a pypi token with the "pypi-" prefix with sufficient permissions to upload this package
         # https://pypi.org/help/#apitoken
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*


### PR DESCRIPTION
Based on https://github.com/bluesky/databroker/blob/master/.github/workflows/publish-pypi.yml.