### PR TITLE
Kafka configuration bug fix

### DIFF
--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -474,7 +474,7 @@ def configure_kafka_publisher(RE, beamline_name):
     )
     # convert the list of bootstrap servers into a comma-delimited string
     #   which is the format required by the confluent python api
-    bootstrap_servers = ",".join(bluesky_kafka_configuration)
+    bootstrap_servers = ",".join(bluesky_kafka_configuration["bootstrap_servers"])
 
     if bluesky_kafka_configuration["abort_run_on_kafka_exception"]:
         _subscribe_kafka_publisher(

--- a/nslsii/tests/test_kafka_conditional_import.py
+++ b/nslsii/tests/test_kafka_conditional_import.py
@@ -81,7 +81,7 @@ def test_conditional_import_positive_case(tmp_path):
     """
 
     # write a temporary file for this test
-    test_config_file_path = tmp_path / "test_bluesky_kafka_config.yml"
+    test_config_file_path = tmp_path / "bluesky_kafka_config_content.yml"
     with open(test_config_file_path, "wt") as f:
         f.write(test_bluesky_kafka_config)
 

--- a/nslsii/tests/test_kafka_publisher.py
+++ b/nslsii/tests/test_kafka_publisher.py
@@ -64,10 +64,7 @@ def test__subscribe_kafka_publisher(
         beamline_topic,
     ):
 
-        (
-            nslsii_beamline_topic,
-            re_subscription_token,
-        ) = nslsii._subscribe_kafka_publisher(
+        subscribe_kafka_publisher_details = nslsii._subscribe_kafka_publisher(
             RE=RE,
             beamline_name=beamline_name,
             bootstrap_servers=kafka_bootstrap_servers,
@@ -78,8 +75,8 @@ def test__subscribe_kafka_publisher(
             },
         )
 
-        assert nslsii_beamline_topic == beamline_topic
-        assert isinstance(re_subscription_token, int)
+        assert subscribe_kafka_publisher_details.beamline_topic == beamline_topic
+        assert isinstance(subscribe_kafka_publisher_details.re_subscribe_token, int)
 
         published_bluesky_documents = []
 
@@ -98,7 +95,7 @@ def test__subscribe_kafka_publisher(
 
         consumed_bluesky_documents = (
             consume_documents_from_kafka_until_first_stop_document(
-                kafka_topic=nslsii_beamline_topic
+                kafka_topic=subscribe_kafka_publisher_details.beamline_topic
             )
         )
 
@@ -151,10 +148,7 @@ def test_no_broker(
         beamline_topic,
     ):
 
-        (
-            nslsii_beamline_topic,
-            re_subscription_token,
-        ) = nslsii._subscribe_kafka_publisher(
+        subscribe_kafka_publisher_details = nslsii._subscribe_kafka_publisher(
             RE=RE,
             beamline_name=beamline_name,
             bootstrap_servers="100.100.100.100:9092",
@@ -165,8 +159,8 @@ def test_no_broker(
             },
         )
 
-        assert nslsii_beamline_topic == beamline_topic
-        assert isinstance(re_subscription_token, int)
+        assert subscribe_kafka_publisher_details.beamline_topic == beamline_topic
+        assert isinstance(subscribe_kafka_publisher_details.re_subscribe_token, int)
 
         published_bluesky_documents = []
 
@@ -219,10 +213,7 @@ def test_exception_on_publisher_call(
             #   but only __call__ will be invoked
             return Mock(side_effect=BlueskyKafkaException)
 
-        (
-            nslsii_beamline_topic,
-            re_subscription_token,
-        ) = nslsii._subscribe_kafka_publisher(
+        subscribe_kafka_publisher_details = nslsii._subscribe_kafka_publisher(
             RE=RE,
             beamline_name=beamline_name,
             bootstrap_servers=kafka_bootstrap_servers,
@@ -235,8 +226,8 @@ def test_exception_on_publisher_call(
             _publisher_factory=mock_publisher_factory,
         )
 
-        assert nslsii_beamline_topic == beamline_topic
-        assert isinstance(re_subscription_token, int)
+        assert subscribe_kafka_publisher_details.beamline_topic == beamline_topic
+        assert isinstance(subscribe_kafka_publisher_details.re_subscribe_token, int)
 
         published_bluesky_documents = []
 

--- a/nslsii/tests/test_kafka_queue_thread_publisher.py
+++ b/nslsii/tests/test_kafka_queue_thread_publisher.py
@@ -1,6 +1,5 @@
 import io
 import logging
-import re
 import uuid
 
 from bluesky.plans import count
@@ -61,11 +60,7 @@ def test_build_and_subscribe_kafka_queue_thread_publisher(
         beamline_topic,
     ):
 
-        (
-            nslsii_beamline_topic,
-            kafka_publisher_thread_exit_event,
-            re_subscription_token,
-        ) = nslsii._subscribe_kafka_queue_thread_publisher(
+        subscribe_kafka_queue_thread_publisher_details = nslsii._subscribe_kafka_queue_thread_publisher(
             RE=RE,
             beamline_name=beamline_name,
             bootstrap_servers=kafka_bootstrap_servers,
@@ -76,8 +71,8 @@ def test_build_and_subscribe_kafka_queue_thread_publisher(
             },
         )
 
-        assert nslsii_beamline_topic == beamline_topic
-        assert isinstance(re_subscription_token, int)
+        assert subscribe_kafka_queue_thread_publisher_details.beamline_topic == beamline_topic
+        assert isinstance(subscribe_kafka_queue_thread_publisher_details.re_subscribe_token, int)
 
         published_bluesky_documents = []
 
@@ -96,7 +91,7 @@ def test_build_and_subscribe_kafka_queue_thread_publisher(
 
         consumed_bluesky_documents = (
             consume_documents_from_kafka_until_first_stop_document(
-                kafka_topic=nslsii_beamline_topic
+                kafka_topic=subscribe_kafka_queue_thread_publisher_details.beamline_topic
             )
         )
 
@@ -167,11 +162,7 @@ def test_publisher_with_no_broker(RE, hw):
     Test the case of no Kafka broker.
     """
     beamline_name = str(uuid.uuid4())[:8]
-    (
-        nslsii_beamline_topic,
-        kafka_publisher_thread_exit_event,
-        subscription_token,
-    ) = nslsii._subscribe_kafka_queue_thread_publisher(
+    subscribe_kafka_queue_thread_publisher_details = nslsii._subscribe_kafka_queue_thread_publisher(
         RE=RE,
         beamline_name=beamline_name,
         # specify a bootstrap server that does not exist
@@ -184,7 +175,7 @@ def test_publisher_with_no_broker(RE, hw):
         publisher_queue_timeout=1,
     )
 
-    assert subscription_token is None
+    assert subscribe_kafka_queue_thread_publisher_details.re_subscribe_token is None
 
     published_bluesky_documents = []
 


### PR DESCRIPTION
There is a bug in the Kafka configuration code that sets the Kafka bootstrap server list to an incorrect value resulting in failure to connect to Kafka brokers even if they are specified correctly in the bluesky Kafka configuration file. This PR fixes the bug and adds additional tests.