### PR TITLE
correct docstring for configure_base

### DIFF
--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -95,7 +95,7 @@ def configure_base(
         True by default. Console output and exception stack traces will be
         written to IPython log file when IPython logging is enabled.
     publish_documents_with_kafka: boolean, optional
-        True by default. If True publish bluesky documents to a Kafka message broker using
+        False by default. If True publish bluesky documents to a Kafka message broker using
         configuration parameters read from a file.
     tb_minimize : boolean, optional
         If IPython should print out 'minimal' tracebacks.

--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -488,7 +488,6 @@ def configure_kafka_publisher(RE, beamline_name, override_config_path=None):
             bootstrap_servers=bootstrap_servers,
             producer_config=bluesky_kafka_configuration["runengine_producer_config"]
         )
-        pass
     else:
         kafka_publisher_details = _subscribe_kafka_queue_thread_publisher(
             RE,


### PR DESCRIPTION
The default value for parameter `publish_documents_with_kafka` was incorrectly reported as 'True'. This PR changes it to the correct value `False`.