### PR TITLE
Improve two-button-shutter stop semantics

### DIFF
--- a/nslsii/devices.py
+++ b/nslsii/devices.py
@@ -123,7 +123,7 @@ class TwoButtonShutter(Device):
         self._was_open = False
         return super().unstage()
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, close_on_pause=True, close_on_stop=True, **kwargs):
         self._was_open = False
         super().__init__(*args, **kwargs)
         self._set_st = None

--- a/nslsii/devices.py
+++ b/nslsii/devices.py
@@ -97,7 +97,7 @@ class TwoButtonShutter(Device):
 
         return st
 
-    def stop(self, *, success=False):
+    def pause(self):
         import time
         prev_st = self._set_st
         if prev_st is not None:


### PR DESCRIPTION
This is code I had sitting around on my computer.

1. One exiting of the run loop the RE stops everything it moves
2. The default "stop" behavior of the shutters is to close themselves
3. This means you can to do `RE(bps.mv(shutter, 'open'))` because it will open and then be helpfully closed 🤦🏻 

We have run into to this at several beamlines (who locally sub-classed and removed the stop method) so we should make it configurable.

Anyone should feel free to take over this PR.