### PR TITLE
Fix mis-use of prefix

### DIFF
--- a/nslsii/tests/test_xspress3.py
+++ b/nslsii/tests/test_xspress3.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from ophyd import ADBase, Component, Kind, Signal
+from ophyd import ADBase, Component, EpicsSignal, Kind, Signal
 
 from nslsii.areadetector.xspress3 import (
     Mca,
@@ -365,7 +365,10 @@ def test_extra_class_members():
         channel_numbers=(3, 5),
         mcaroi_numbers=(4, 6),
         image_data_key="image",
-        extra_class_members={"ten": 10, "a_signal": Component(Signal, value=0)},
+        extra_class_members={
+            "ten": 10,
+            "a_signal": Component(EpicsSignal, "Signal")
+        },
     )
 
     assert detector_class.ten == 10
@@ -375,7 +378,7 @@ def test_extra_class_members():
 
     assert detector.ten == 10
     assert isinstance(detector.a_signal, Signal)
-    assert detector.a_signal.get() == 0
+    assert detector.a_signal.pvname == "Xsp3:Signal"
 
 
 def test_extra_class_members_failure():

--- a/nslsii/tests/test_xspress3_with_hw.py
+++ b/nslsii/tests/test_xspress3_with_hw.py
@@ -38,8 +38,8 @@ def test_hdf5plugin(xs3_pv_prefix):
         extra_class_members={
             "hdf5plugin": Component(
                 Xspress3HDF5Plugin,
+                "HDF1:",
                 name="h5p",
-                prefix=f"{xs3_pv_prefix}HDF1:",
                 root_path="/a/b/c",
                 path_template="/a/b/c/%Y/%m/%d",
                 resource_kwargs={},
@@ -100,8 +100,8 @@ def test_trigger(xs3_pv_prefix, xs3_root_path, xs3_path_template):
         extra_class_members={
             "hdf5plugin": Component(
                 Xspress3HDF5Plugin,
+                "HDF1:",
                 name="h5p",
-                prefix=f"{xs3_pv_prefix}HDF1:",
                 root_path=xs3_root_path,
                 path_template=xs3_path_template,
                 resource_kwargs={},
@@ -200,8 +200,8 @@ def test_document_stream(
         extra_class_members={
             "hdf5plugin": Component(
                 Xspress3HDF5Plugin,
+                "HDF1:",
                 name="h5p",
-                prefix=f"{xs3_pv_prefix}HDF1:",
                 root_path=xs3_root_path,
                 path_template=xs3_path_template,
                 resource_kwargs={},


### PR DESCRIPTION
This PR makes a small but important correction to the way HDF5Plugins were initialized in tests. The `prefix=` keyword argument should not have been used as it was. It has been replaced with the proper positional argument.