### PR TITLE
Add dtype_str parameter to Xspress3ExternalFileReference.__init__

### DIFF
--- a/nslsii/areadetector/xspress3.py
+++ b/nslsii/areadetector/xspress3.py
@@ -122,10 +122,23 @@ class Xspress3Trigger(Device):
 
 
 class Xspress3ExternalFileReference(Signal):
-    """ A special Signal for datum document information. """
+    """ A special Signal for datum document information.
 
-    def __init__(self, *args, bin_count=4096, dim_name="bin_count", **kwargs):
+    Parameters
+    ----------
+    dtype_str: str
+        numpy type string describing the array data saved by the xspress3,
+        allowed values are found in numpy.sctypeDict, default is "uint32"
+    bin_count: int
+        number of bins in the array data, default is 4096
+    dim_name: str
+        name for the first dimension of the array data, default is "bin_count"
+
+    """
+
+    def __init__(self, *args, dtype_str="uint32", bin_count=4096, dim_name="bin_count", **kwargs):
         super().__init__(*args, **kwargs)
+        self.dtype_str = dtype_str
         self.shape = (bin_count,)
         self.dims = (dim_name,)
 
@@ -135,7 +148,7 @@ class Xspress3ExternalFileReference(Signal):
             dict(
                 external="FILESTORE:",
                 dtype="array",
-                dtype_str="uint32",  # <u4
+                dtype_str=self.dtype_str,
                 shape=self.shape,
                 dims=self.dims,
             )

--- a/nslsii/tests/test_xspress3.py
+++ b/nslsii/tests/test_xspress3.py
@@ -141,6 +141,9 @@ def test_instantiate_channel_class():
     )
     channel_2 = channel_class(prefix="Xsp3:", name="channel_2")
 
+    assert channel_2.image.dtype_str == "uint32"
+    assert channel_2.image.shape == (4096,)
+    assert channel_2.image.dims == ("bin_count",)
     assert channel_2.get_external_file_ref().name == "channel_2_image"
 
     assert channel_2.sca.clock_ticks.pvname == "Xsp3:C2SCA:0:Value_RBV"


### PR DESCRIPTION
This PR proposes an additional parameter, `dtype_str`, for `Xspress3ExternalFileReference.__init__`. In addition a member variable is added to hold the `dtype_str` value and use it to when `describe()` is called. This allows user code to modify the array data type, which is not always `uint32` as was discovered at BMM.