### PR TITLE
Pin Kafka and Zookeeper versions and remove unused code

### DIFF
--- a/scripts/bitnami-kafka-docker-compose.yml
+++ b/scripts/bitnami-kafka-docker-compose.yml
@@ -2,37 +2,21 @@ version: '3'
 
 services:
   zookeeper:
-    image: 'docker.io/bitnami/zookeeper:latest'
+    image: 'docker.io/bitnami/zookeeper:3.8'
     ports:
       - '2181:2181'
-    #volumes:
-    #  - 'zookeeper_data:/bitnami'
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
   kafka:
-    image: 'docker.io/bitnami/kafka:latest'
+    image: 'docker.io/bitnami/kafka:2.8'
     ports:
       - '9092:9092'
-      #- '29092:29092'
-    #volumes:
-    #  - 'kafka_data:/bitnami'
     environment:
       - KAFKA_BROKER_ID=1
       - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
       - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
       - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
       - ALLOW_PLAINTEXT_LISTENER=yes
-      #- KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
       - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=false
-      #- ALLOW_PLAINTEXT_LISTENER=yes
-      #- KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      #- KAFKA_CFG_LISTENERS=PLAINTEXT://:29092,PLAINTEXT_HOST://:9092
-      #- KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
     depends_on:
       - zookeeper
-
-#volumes:
-#  zookeeper_data:
-#    driver: local
-#  kafka_data:
-#    driver: local


### PR DESCRIPTION
The "latest" version of Kafka no longer uses Zookeeper, so this configuration pins both to versions that will work together.