### PR TITLE
feat: add pmac kill signal and switch

### DIFF
--- a/nslsii/motors/delta_tau.py
+++ b/nslsii/motors/delta_tau.py
@@ -23,8 +23,8 @@ class PMACStatus(EpicsSignalRO):
 class PMACKillSwitch(Device):
     """
     A device to kill the PMAC-PC controller.
-    In the named version of the EPICS record, the status is expected at Sts:4-Sts.
-    Whereas in the axis numbered version, the status is expected at Sts:1-Sts.
+    In the named version of the EPICS record (e.g., XF:23ID1-ES{Dif-Ax:Del}), the status is expected at Sts:4-Sts.
+    Whereas in the axis numbered version (e.g., XF:23ID1-CT{MC:12-Ax:1}), the status is expected at Sts:1-Sts.
     """
 
     kill = Cpt(EpicsSignal, "Cmd:Kill-Cmd.PROC", kind=Kind.omitted)

--- a/nslsii/motors/delta_tau.py
+++ b/nslsii/motors/delta_tau.py
@@ -6,7 +6,6 @@ import logging
 
 from ophyd import Component as Cpt
 from ophyd import Device, EpicsSignal, EpicsSignalRO, Kind
-from ophyd.utils.epics_pvs import raise_if_disconnected
 
 
 class PMACStatus(EpicsSignalRO):
@@ -14,10 +13,8 @@ class PMACStatus(EpicsSignalRO):
     A signal to read the status of the PMAC-PC controller by checking the bit 11 of the status register.
     """
 
-    @raise_if_disconnected
-    def read(self):
-        value = self.get() >> 11 & 1 == 0
-        return {self.name: {"value": value, "timestamp": self.timestamp}}
+    def get(self):
+        return int(super().get() >> 11 & 1 == 0)
 
 
 class PMACKillSwitch(Device):
@@ -40,3 +37,9 @@ class PMACKillSwitch(Device):
             )
             value = 1
         self.kill.set(value, *args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        """
+        Get the value of the kill switch
+        """
+        return self.status.get(*args, **kwargs)

--- a/nslsii/motors/delta_tau.py
+++ b/nslsii/motors/delta_tau.py
@@ -1,0 +1,42 @@
+"""
+Ophyd devices and signals for Delta Tau devices, such as Programmable Multi-Axis Controller (PMAC-PC)
+"""
+
+import logging
+
+from ophyd import Component as Cpt
+from ophyd import Device, EpicsSignal, EpicsSignalRO, Kind
+from ophyd.utils.epics_pvs import raise_if_disconnected
+
+
+class PMACStatus(EpicsSignalRO):
+    """
+    A signal to read the status of the PMAC-PC controller by checking the bit 11 of the status register.
+    """
+
+    @raise_if_disconnected
+    def read(self):
+        value = self.get() >> 11 & 1 == 0
+        return {self.name: {"value": value, "timestamp": self.timestamp}}
+
+
+class PMACKillSwitch(Device):
+    """
+    A device to kill the PMAC-PC controller.
+    In the named version of the EPICS record, the status is expected at Sts:4-Sts.
+    Whereas in the axis numbered version, the status is expected at Sts:1-Sts.
+    """
+
+    kill = Cpt(EpicsSignal, "Cmd:Kill-Cmd.PROC", kind=Kind.omitted)
+    status = Cpt(PMACStatus, "Sts:4-Sts", kind=Kind.normal)
+
+    def set(self, value, *args, **kwargs):
+        """
+        Set the kill switch to the given value
+        """
+        if value != 1:
+            logging.getLogger(__name__).warning(
+                "The value of the PMACKiller should only ever be set to 1. " "Changing the setpoint to 1 now."
+            )
+            value = 1
+        self.kill.set(value, *args, **kwargs)


### PR DESCRIPTION
In response to https://github.com/NSLS-II-CSX/profile_collection/issues/84. 

Initially, an EPICS record was added to include a custom PV for Kill Status that would grab the 11th bit from the status. This moves that logic to the ophyd level, and constructs an appropriate switch that can kill a PMAC and check if the PMAC is killed. 


## TODO: 
- [x] Confirm that the naming approach is appropriate and broadly applicable. 