### PR TITLE
Use correct number of dimension names in Xspress3ExternalFileReference

### DIFF
--- a/nslsii/areadetector/xspress3.py
+++ b/nslsii/areadetector/xspress3.py
@@ -136,11 +136,14 @@ class Xspress3ExternalFileReference(Signal):
 
     """
 
-    def __init__(self, *args, dtype_str="uint32", bin_count=4096, dim_name="bin_count", **kwargs):
+    def __init__(self, *args, dtype_str="uint32", bin_count=4096, dim_name=["frame_number", "number_channels", "bin_count"], **kwargs):
         super().__init__(*args, **kwargs)
         self.dtype_str = dtype_str
         self.shape = (bin_count,)
-        self.dims = (dim_name,)
+        if isinstance(dim_name, str):
+            self.dims = (dim_name,) # Keeping this option for backwards compatibility with some beamlines
+        else:
+            self.dims = (*dim_name,)
 
     def describe(self):
         res = super().describe()

--- a/nslsii/areadetector/xspress3.py
+++ b/nslsii/areadetector/xspress3.py
@@ -141,7 +141,7 @@ class Xspress3ExternalFileReference(Signal):
         self.dtype_str = dtype_str
         self.shape = (bin_count,)
         if isinstance(dim_name, str):
-            self.dims = (dim_name,) # Keeping this option for backwards compatibility with some beamlines
+            self.dims = (dim_name,)  # Keeping this option for backward compatibility with some beamlines
         elif isinstance(dim_name, list):
             self.dims = (*dim_name,)
         else:

--- a/nslsii/areadetector/xspress3.py
+++ b/nslsii/areadetector/xspress3.py
@@ -136,14 +136,16 @@ class Xspress3ExternalFileReference(Signal):
 
     """
 
-    def __init__(self, *args, dtype_str="uint32", bin_count=4096, dim_name=["frame_number", "number_channels", "bin_count"], **kwargs):
+    def __init__(self, *args, dtype_str="uint32", bin_count=4096, dim_name=("frame_number", "number_channels", "bin_count"), **kwargs):
         super().__init__(*args, **kwargs)
         self.dtype_str = dtype_str
         self.shape = (bin_count,)
         if isinstance(dim_name, str):
             self.dims = (dim_name,) # Keeping this option for backwards compatibility with some beamlines
-        else:
+        elif isinstance(dim_name, list):
             self.dims = (*dim_name,)
+        else:
+            self.dims = dim_name
 
     def describe(self):
         res = super().describe()

--- a/nslsii/tests/test_xspress3.py
+++ b/nslsii/tests/test_xspress3.py
@@ -143,7 +143,7 @@ def test_instantiate_channel_class():
 
     assert channel_2.image.dtype_str == "uint32"
     assert channel_2.image.shape == (4096,)
-    assert channel_2.image.dims == ('frame_number', 'number_channels', 'bin_count',)
+    assert channel_2.image.dims == ("frame_number", "number_channels", "bin_count",)
     assert channel_2.get_external_file_ref().name == "channel_2_image"
 
     assert channel_2.sca.clock_ticks.pvname == "Xsp3:C2SCA:0:Value_RBV"

--- a/nslsii/tests/test_xspress3.py
+++ b/nslsii/tests/test_xspress3.py
@@ -143,7 +143,7 @@ def test_instantiate_channel_class():
 
     assert channel_2.image.dtype_str == "uint32"
     assert channel_2.image.shape == (4096,)
-    assert channel_2.image.dims == ("bin_count",)
+    assert channel_2.image.dims == ('frame_number', 'number_channels', 'bin_count',)
     assert channel_2.get_external_file_ref().name == "channel_2_image"
 
     assert channel_2.sca.clock_ticks.pvname == "Xsp3:C2SCA:0:Value_RBV"


### PR DESCRIPTION
This PR fixes an error that was identified in https://github.com/bluesky/databroker/pull/793 during tests for the Data Security project at SRX.
The error was tracked from tiled, back to databoker and last here where the default information of the dimensions of an Xspress3ExternalFileReference was being saved in a BlueSky document and this was causing an error while using this information and data to create an array in an xarray.Dataset.
The definition of `dim_name` was modified which considers the correct dimensions of the array and fixes the error when xarrays are generated in databroker.
The original use of `dim_name` was kept for cases where backwards compatibility is necessary.