### PR TITLE
Update PyPI when release is created or published

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,7 +7,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [created, published]
 
 jobs:
   deploy:


### PR DESCRIPTION
This should handle the case of draft releases that currently do not trigger this GHA.

https://stackoverflow.com/a/61066906
https://github.com/pypa/gh-action-pypi-publish/discussions/28#discussioncomment-79858