### PR TITLE
Refactor auth mechanism in sync-experiment

### DIFF
--- a/nslsii/sync_experiment/__init__.py
+++ b/nslsii/sync_experiment/__init__.py
@@ -1,1 +1,1 @@
-from .sync_experiment import main, sync_experiment, validate_proposal
+from .sync_experiment import main, sync_experiment, validate_proposal, switch_redis_proposal

--- a/nslsii/sync_experiment/sync_experiment.py
+++ b/nslsii/sync_experiment/sync_experiment.py
@@ -182,6 +182,8 @@ def sync_experiment(proposal_number, beamline, username, verbose=False, prefix="
             print("Users:")
             print(users)
 
+    return md
+
 
 def main():
     # Used by the `sync-experiment` command

--- a/nslsii/sync_experiment/sync_experiment.py
+++ b/nslsii/sync_experiment/sync_experiment.py
@@ -142,7 +142,7 @@ def switch_redis_proposal(
     username : str or None
         login name of the user assigned to the proposal; if None, current user will be kept
     prefix : str
-        optional prefix to identigy a specific endstation, e.g. `opls`
+        optional prefix to identify a specific endstation, e.g. `opls`
 
     Returns
     -------

--- a/nslsii/sync_experiment/sync_experiment.py
+++ b/nslsii/sync_experiment/sync_experiment.py
@@ -133,7 +133,7 @@ def switch_redis_proposal(
 ) -> RedisJSONDict:
     """Update information in RedisJSONDict for a specific beamline
 
-    Paraneters
+    Parameters
     ----------
     proposal_number : int or str
         number of the desired proposal, e.g. `123456`


### PR DESCRIPTION
Context: Some beamlines (e.g. SMI) collect data on multiple proposals during the same run to make use of the same environment conditions between the experiments (e.g. temperature); changing these conditions often would unnecessarily require too much downtime for the instruments.
Our current `sync-experiment` workflow assumes that a user (or a beamline scientist) switches to a new proposal at the beginning of acquisition (possibly even before opening `bsui`). This would be impractical for highly dynamic or automated plans as above.

This PR Separates the authentication mechanism in the internal `sync_experiment` function from the updating of the redis dictionary. This would allow us to switch between multiple proposals within a profile_collection plan (using the new `switch_redis_proposal(proposal_number, beamline, username, prefix)` function -- SMI already have [something very similar](https://github.com/NSLS-II-SMI/profile_collection/blob/8edf9752102dc37e52b63d483e3722aac7123700/startup/80-config.py#L52) that they extensively use in their profile collection, and the idea is to just replace it). This function will still check if a user has the rights to collect data on a proposal, but wouldn't ask for their password. We will need that before running `bsui` or in the base step of profile collection, the user properly authenticates with `sync-experiment` (this is effectively an honor system, but writing the data in a correct location is is in their interests, because otherwise they won't be able to read it).

These refactoring changes will not break any existing deployments.