### PR TITLE
Remove 'finally' that is eating exceptions

### DIFF
--- a/nslsii/sync_experiment/sync_experiment.py
+++ b/nslsii/sync_experiment/sync_experiment.py
@@ -82,8 +82,7 @@ def validate_proposal(data_session_value, beamline) -> Dict[str, Any]:
             f"'{rerr}'"
         )
 
-    finally:
-        return proposal_data
+    return proposal_data
 
 
 def authenticate(username):


### PR DESCRIPTION
This bug was enabling access to all of the facility's proposals if a user had access to all of any one beamline's proposals.