### PR TITLE
CI: only use the `published` event for PyPI releases

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,7 +7,8 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created, published]
+    types:
+      - published
 
 jobs:
   deploy:


### PR DESCRIPTION
This PR is to follow up on #197 (per https://stackoverflow.com/a/61066906) to avoid a duplicate execution of the same CD workflow, as happened with the v0.10.6 release:

![image](https://github.com/user-attachments/assets/52bc1f8a-86fd-4b4d-8294-293e2e18265a)