### PR TITLE
Deprecate the webcam class

### DIFF
--- a/nslsii/detectors/webcam.py
+++ b/nslsii/detectors/webcam.py
@@ -1,14 +1,14 @@
 import datetime
+import itertools
 import logging
 import time as ttime
+import warnings
 from collections import deque
-import itertools
 from pathlib import Path
 
 import cv2
 import h5py
 import numpy as np
-from area_detector_handlers.handlers import HandlerBase
 from event_model import compose_resource
 from ophyd import Component as Cpt
 from ophyd import Device, Signal
@@ -17,7 +17,6 @@ from ophyd.sim import NullStatus, new_uid
 from nslsii.iocs.caproto_saver import ExternalFileReference
 
 logger = logging.getLogger("vstream")
-
 
 
 class VideoStreamDet(Device):
@@ -34,6 +33,10 @@ class VideoStreamDet(Device):
         frame_shape=(1080, 1920),
         **kwargs,
     ):
+        warnings.warn(
+            f"This class {self.__class__.__name__} will be removed in the future."
+        )
+
         super().__init__(*args, **kwargs)
 
         self._root_dir = root_dir
@@ -73,13 +76,14 @@ class VideoStreamDet(Device):
 
         self._h5file_desc = h5py.File(self._data_file, "x")
         group = self._h5file_desc.create_group("/entry")
-        self._dataset = group.create_dataset("averaged",
-                                             data=np.full(fill_value=np.nan,
-                                                          shape=(1, *self._frame_shape)),
-                                             maxshape=(None, *self._frame_shape),
-                                             chunks=(1, *self._frame_shape),
-                                             dtype="float64",
-                                             compression="lzf")
+        self._dataset = group.create_dataset(
+            "averaged",
+            data=np.full(fill_value=np.nan, shape=(1, *self._frame_shape)),
+            maxshape=(None, *self._frame_shape),
+            chunks=(1, *self._frame_shape),
+            dtype="float64",
+            compression="lzf",
+        )
         self._counter = itertools.count()
 
     def trigger(self, *args, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 appdirs
-bluesky>=1.8.1
 bluesky-kafka>=0.8.0
+bluesky>=1.8.1
 caproto
 databroker
 h5py
@@ -12,6 +12,7 @@ matplotlib
 msgpack >=1.0.0
 msgpack-numpy
 numpy
+opencv-python
 ophyd
 ophyd-async
 packaging


### PR DESCRIPTION
The `VideoStreamDet` class will be removed in the future as it will be replaced with caproto IOCs on the beamlines which need this functionality.