### PR TITLE
fix: default broker to None

### DIFF
--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -28,7 +28,7 @@ def import_star(module, ns):
 
 def configure_base(
     user_ns,
-    broker_name,
+    broker_name=None,
     *,
     bec=True,
     bec_derivative=False,
@@ -72,8 +72,8 @@ def configure_base(
     ----------
     user_ns: dict
         a namespace --- for example, ``get_ipython().user_ns``
-    broker_name : Union[str, Broker]
-        Name of databroker configuration or a Broker instance.
+    broker_name : Union[str, Broker, None], optional
+        Name of databroker configuration or a Broker instance. If None, no RE subscription is made
     bec : boolean, optional
         True by default. Set False to skip BestEffortCallback.
     bec_derivative : boolean, optional
@@ -163,8 +163,8 @@ def configure_base(
         ns["db"] = db
     else:
         db = broker_name
-
-    RE.subscribe(db.insert)
+    if db is not None:
+        RE.subscribe(db.insert)
 
     if pbar:
         # Add a progress bar.


### PR DESCRIPTION
Data security changes are creating a subscription to a `db.insert` and then promptly removing this in favor a tiled writing client. See [BMM Profile](https://github.com/NSLS-II-BMM/profile_collection/blob/e4f3670f5de7d6d91c9e26c89e2a66197a2670a8/startup/BMM/user_ns/base.py#L41-L42). 

This is not only sloppy, but causes failures in any services that cannot create a broker in that fashion (e.g., QueueServer). 