### PR TITLE
🔄 SYNC EXPERIMENT: Always update cycle in Redis, even if the proposal is open already.

### DIFF
--- a/nslsii/sync_experiment/sync_experiment.py
+++ b/nslsii/sync_experiment/sync_experiment.py
@@ -184,6 +184,12 @@ def switch_redis_proposal(
     if (new_data_session == md.get("data_session")) and (
         username == md.get("username")
     ):
+        # The cycle needs to get updated regardless of experiment status
+        md["cycle"] = (
+            "commissioning"
+            if is_commissioning_proposal(str(proposal_number), beamline)
+            else get_current_cycle()
+        )
         warnings.warn(
             f"Experiment {new_data_session} was already started by the same user."
         )


### PR DESCRIPTION
This corrects an issue that @bruceravel observed at BMM when using the *Sync Experiment* utility.
A large block of code updating redis gets short circuited when the proposal isn't being switched.
[Slack thread](https://nsls2.slack.com/archives/C02D9V72QH1/p1746543288910899)