### PR TITLE
add option for broker_name to be a TiledWriter object

### DIFF
--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -164,12 +164,11 @@ def configure_base(
         db = broker_name
 
     if db is not None:
-        from bluesky.callbacks.tiled_writer import TiledWriter
-        if isinstance(db, TiledWriter):
-            # subscribe to the TiledWriter
-            RE.subscribe(db)
-        else:
+        if isinstance(db, Broker):
+            # subscribe to the Broker
             RE.subscribe(db.insert)
+        else:
+            RE.subscribe(db)
 
     if pbar:
         # Add a progress bar.

--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -162,8 +162,14 @@ def configure_base(
         ns["db"] = db
     else:
         db = broker_name
+
     if db is not None:
-        RE.subscribe(db.insert)
+        from bluesky.callbacks.tiled_writer import TiledWriter
+        if isinstance(db, TiledWriter):
+            # subscribe to the TiledWriter
+            RE.subscribe(db)
+        else:
+            RE.subscribe(db.insert)
 
     if pbar:
         # Add a progress bar.

--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -164,8 +164,8 @@ def configure_base(
         db = broker_name
 
     if db is not None:
-        if isinstance(db, Broker):
-            # subscribe to the Broker
+        if hasattr(db, "insert"):
+            # subscribe using insert if it exists
             RE.subscribe(db.insert)
         else:
             RE.subscribe(db)


### PR DESCRIPTION
Attempting to resolve #226 
I figured the best way to stay consistent with backwards compatibility would be to keep `db` defined the same way but later check if it is an object of TiledWriter. The subscribe directly to that instead of calling `.insert`. This should alleviate the problem of creating the `TiledInserter` during data security.