### PR TITLE
Fixing some inconsistent arguments for Redis in configure_base

### DIFF
--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -146,8 +146,12 @@ def configure_base(
         from redis import Redis
         from redis_json_dict import RedisJSONDict
 
-        redis_client = open_redis_client(redis_ssl=redis_ssl, redis_url=redis_url, redis_prefix=redis_prefix)
-        prefix = redis_prefix if redis_prefix and not redis_ssl else ""
+        redis_client = open_redis_client(
+            redis_ssl=redis_ssl,
+            redis_url=redis_url,
+            redis_port=redis_port,
+        )
+        prefix = redis_prefix if redis_prefix else ""
         md = RedisJSONDict(redis_client=redis_client, prefix=prefix)
 
     # if RunEngine already defined grab it

--- a/nslsii/utils.py
+++ b/nslsii/utils.py
@@ -45,7 +45,6 @@ def open_redis_client(
     redis_url=None,
     redis_port=None,
     redis_ssl=False,
-    redis_prefix: str = "",
     redis_db: int = 0,
 ) -> Redis:
     """
@@ -55,9 +54,7 @@ def open_redis_client(
         redis_url = os.getenv("REDIS_HOST")
     if redis_url is None:
         if redis_ssl:
-            client_loc_id = (
-                redis_prefix if redis_prefix else socket.gethostname().split("-")[0]
-            )
+            client_loc_id = socket.gethostname().split("-")[0]
             client_locations = [
                 location for location in redis_hosts if client_loc_id in location
             ]


### PR DESCRIPTION
Fixing some inconsistencies in the Redis setup

- `redis_port` argument was not being passed through to `open_redis_client`
  - *enables the use of a custom port for development purposes*
- `open_redis_client` should not have anything to do with `redis_prefix`
  - *A prefix is only relevant to the metadata dictionary, not relevant to establishing a connection*
- `redis_prefix` must be enabled even when using `redis_ssl=True`
  - *A prefix must be allowed for the metadata dictionary, since the same beamline might want different sets of metadata*

The last point is relevant to SIX, they have different set of metadata for their SIX endstation versus their Keithley endstation, which they select when IPython starts up.