### PR TITLE
ENH: add `--version`/`-V` argument to `sync-experiment` CLI

### DIFF
--- a/nslsii/sync_experiment/sync_experiment.py
+++ b/nslsii/sync_experiment/sync_experiment.py
@@ -1,4 +1,5 @@
 import argparse
+import importlib.metadata
 import os
 import re
 import warnings
@@ -340,6 +341,12 @@ def main():
         dest="redis_ssl",
         action="store_true",
         help="Flag to enable ssl connection with redis",
+    )
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=f"%(prog)s {importlib.metadata.version('nslsii')}",
     )
     parser.add_argument("-v", "--verbose", action=argparse.BooleanOptionalAction)
     args = parser.parse_args()


### PR DESCRIPTION
Add a `-V`/`--version` flag to the sync-experiment argparse CLI that prints the installed `nslsii` package version using `importlib.metadata`.

Usage example:
```bash
❯ sync-experiment --version
sync-experiment 0.11.9+2.g60846da.dirty
```