### PR TITLE
Add Eurotherm3k ophyd-async device (HXM-1305)

### DIFF
--- a/nslsii/ophyd_async/devices/__init__.py
+++ b/nslsii/ophyd_async/devices/__init__.py
@@ -1,10 +1,17 @@
-from rbd9103 import (
+from .rbd9103 import (
     RBD9103,
     RBD9103Range,
     RBD9103Input,
     RBD9103SamplingMode,
     RBD9103InRangeState,
     RBD9103Filter,
+)
+from .eurotherm3k import (
+    Eurotherm3k,
+    Eurotherm3kLoop,
+    Eurotherm3kControlMode,
+    Eurotherm3kOnOff,
+    Eurotherm3kRampRateUnit,
 )
 
 __all__ = [
@@ -14,4 +21,9 @@ __all__ = [
     "RBD9103SamplingMode",
     "RBD9103InRangeState",
     "RBD9103Filter",
+    "Eurotherm3k",
+    "Eurotherm3kLoop",
+    "Eurotherm3kControlMode",
+    "Eurotherm3kOnOff",
+    "Eurotherm3kRampRateUnit",
 ]

--- a/nslsii/ophyd_async/devices/eurotherm3k.py
+++ b/nslsii/ophyd_async/devices/eurotherm3k.py
@@ -1,4 +1,4 @@
-import time
+import asyncio
 from typing import Annotated as A
 
 from ophyd_async.core import (
@@ -69,21 +69,37 @@ class Eurotherm3kLoop(StandardReadable, EpicsDevice):
     async def set(self, value: float) -> None:
         # 1. command the setpoint (waits for the write to be accepted)
         await self.setpoint.set(value)
-        # 2. watch the readback until it settles, or time out overall
-        in_band_since: float | None = None
-        async for current in observe_value(
-            self.readback, done_timeout=self.move_timeout
-        ):
-            if abs(current - value) <= self.tolerance:
+
+        async def _reach_band() -> None:
+            """Return once the readback is within tolerance of the target."""
+            async for current in observe_value(self.readback):
+                if abs(current - value) <= self.tolerance:
+                    return
+
+        async def _leave_band() -> None:
+            """Return if/when the readback leaves the tolerance band."""
+            async for current in observe_value(self.readback):
+                if abs(current - value) > self.tolerance:
+                    return
+
+        async def _settle() -> None:
+            while True:
+                await _reach_band()
                 if self.settle_time <= 0:
                     return  # "first touch" mode: done
-                now = time.monotonic()
-                if in_band_since is None:
-                    in_band_since = now  # entered the band, start the hold timer
-                elif now - in_band_since >= self.settle_time:
-                    return  # held in band long enough: done
-            else:
-                in_band_since = None  # left the band, reset the hold timer
+                try:
+                    # Stay settled unless the readback leaves the band within
+                    # settle_time. A stable PV that stops updating while in band
+                    # just times out here -> treated as "held long enough", so a
+                    # settled controller no longer blocks until move_timeout.
+                    await asyncio.wait_for(_leave_band(), timeout=self.settle_time)
+                except asyncio.TimeoutError:
+                    return  # held in band for settle_time: done
+                # left the band before settling -> loop and re-reach
+
+        # Enforce the overall timeout. On Python >= 3.11 asyncio.TimeoutError is
+        # the builtin TimeoutError, so callers can catch TimeoutError.
+        await asyncio.wait_for(_settle(), timeout=self.move_timeout)
 
 
 class Eurotherm3k(StandardReadable, EpicsDevice):

--- a/nslsii/ophyd_async/devices/eurotherm3k.py
+++ b/nslsii/ophyd_async/devices/eurotherm3k.py
@@ -1,0 +1,106 @@
+import time
+from typing import Annotated as A
+
+from ophyd_async.core import (
+    AsyncStatus,
+    SignalR,
+    SignalRW,
+    StandardReadable,
+    StrictEnum,
+    observe_value,
+)
+from ophyd_async.core import StandardReadableFormat as Format
+from ophyd_async.epics.core import EpicsDevice, PvSuffix
+
+
+class Eurotherm3kControlMode(StrictEnum):
+    AUTOMATIC = "Automatic"
+    MANUAL = "Manual"
+
+
+class Eurotherm3kOnOff(StrictEnum):
+    OFF = "Off"
+    ON = "On"
+
+
+class Eurotherm3kRampRateUnit(StrictEnum):
+    PER_SECOND = "C/s"
+    PER_MINUTE = "C/min"
+
+
+class Eurotherm3kLoop(StandardReadable, EpicsDevice):
+    """One PID control loop of a Eurotherm 3000-series controller.
+
+    Behaves as a settable temperature axis: ``set(T)`` writes the setpoint and
+    completes once the readback has settled within ``tolerance`` of ``T``.
+    """
+
+    # Settle behaviour (override per instance, e.g. ``dev.loop1.tolerance = 0.5``)
+    tolerance = 1.0  # deg: |readback - setpoint| band counted as "there"
+    settle_time = 0.0  # s: must stay in band this long (0.0 = first touch)
+    move_timeout = 3600.0  # s: overall timeout for a move
+
+    setpoint: A[SignalRW[float], PvSuffix.rbv("SP", ":RBV")]
+    readback: A[SignalR[float], PvSuffix("PV:RBV"), Format.HINTED_SIGNAL]
+    working_setpoint: A[SignalR[float], PvSuffix("WSP:RBV")]
+    ramp_rate: A[SignalRW[float], PvSuffix.rbv("RR", ":RBV"), Format.CONFIG_SIGNAL]
+    ramp_rate_unit: A[
+        SignalR[Eurotherm3kRampRateUnit], PvSuffix("RR:UNIT"), Format.CONFIG_SIGNAL
+    ]
+    p: A[SignalRW[float], PvSuffix.rbv("P", ":RBV"), Format.CONFIG_SIGNAL]
+    i: A[SignalRW[float], PvSuffix.rbv("I", ":RBV"), Format.CONFIG_SIGNAL]
+    d: A[SignalRW[float], PvSuffix.rbv("D", ":RBV"), Format.CONFIG_SIGNAL]
+    control_mode: A[
+        SignalRW[Eurotherm3kControlMode],
+        PvSuffix.rbv("MAN", ":RBV"),
+        Format.CONFIG_SIGNAL,
+    ]
+    autotune: A[SignalRW[Eurotherm3kOnOff], PvSuffix.rbv("AUTOTUNE", ":RBV")]
+    output: A[SignalRW[float], PvSuffix.rbv("O", ":RBV")]
+    output_high: A[
+        SignalRW[float], PvSuffix.rbv("OUTPHI", ":RBV"), Format.CONFIG_SIGNAL
+    ]
+    output_low: A[SignalRW[float], PvSuffix.rbv("OUTPLO", ":RBV"), Format.CONFIG_SIGNAL]
+    loop_break_time: A[
+        SignalRW[float], PvSuffix.rbv("LBT", ":RBV"), Format.CONFIG_SIGNAL
+    ]
+
+    @AsyncStatus.wrap
+    async def set(self, value: float) -> None:
+        # 1. command the setpoint (waits for the write to be accepted)
+        await self.setpoint.set(value)
+        # 2. watch the readback until it settles, or time out overall
+        in_band_since: float | None = None
+        async for current in observe_value(
+            self.readback, done_timeout=self.move_timeout
+        ):
+            if abs(current - value) <= self.tolerance:
+                if self.settle_time <= 0:
+                    return  # "first touch" mode: done
+                now = time.monotonic()
+                if in_band_since is None:
+                    in_band_since = now  # entered the band, start the hold timer
+                elif now - in_band_since >= self.settle_time:
+                    return  # held in band long enough: done
+            else:
+                in_band_since = None  # left the band, reset the hold timer
+
+
+class Eurotherm3k(StandardReadable, EpicsDevice):
+    """Eurotherm 3000-series controller (nsls2.ioc_deploy eurotherm3k role)."""
+
+    loop1: A[Eurotherm3kLoop, PvSuffix("LOOP1:"), Format.CHILD]
+    loop2: A[Eurotherm3kLoop, PvSuffix("LOOP2:"), Format.CHILD]
+
+    # --- Global (controller-wide) ---
+    disable: A[SignalRW[str], PvSuffix("DISABLE"), Format.CONFIG_SIGNAL]
+    programmer_number: A[
+        SignalRW[int], PvSuffix.rbv("PROGNUM", ":RBV"), Format.CONFIG_SIGNAL
+    ]
+    programmer_run: A[SignalRW[bool], PvSuffix.rbv("PROGRUN", ":RBV")]
+    programmer_reset: A[SignalRW[bool], PvSuffix("PROGRESET")]
+    programmer_status: A[SignalR[str], PvSuffix("PROGSTAT:RBV")]
+    recipe_select: A[
+        SignalRW[str], PvSuffix.rbv("RECSEL", ":RBV"), Format.CONFIG_SIGNAL
+    ]
+    recipe_status: A[SignalR[str], PvSuffix("RECSTAT:RBV")]

--- a/nslsii/ophyd_async/devices/rbd9103.py
+++ b/nslsii/ophyd_async/devices/rbd9103.py
@@ -6,7 +6,7 @@ from ophyd_async.core import (
     AsyncStatus,
 )
 from ophyd_async.core import StandardReadableFormat as Format
-from ophyd_async.epics.signal import PvSuffix, EpicsDevice
+from ophyd_async.epics.core import PvSuffix, EpicsDevice
 from typing import Annotated as A
 
 

--- a/nslsii/tests/ophyd_async/test_eurotherm3k.py
+++ b/nslsii/tests/ophyd_async/test_eurotherm3k.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from ophyd_async.core import get_mock_put, init_devices, set_mock_value
 
@@ -48,7 +50,28 @@ async def test_set_commands_setpoint_and_settles():
     # pretend the controller is already at temperature
     set_mock_value(dev.loop1.readback, 300.0)
     await dev.loop1.set(300.0)  # returns => it settled
-    get_mock_put(dev.loop1.setpoint).assert_called_once()  # and it wrote the setpoint
+    # it wrote the commanded setpoint (not just "something")
+    get_mock_put(dev.loop1.setpoint).assert_called_once_with(300.0)
+
+
+@pytest.mark.asyncio
+async def test_set_holds_in_band_for_settle_time():
+    """With settle_time > 0, set() waits the hold time even if the readback is
+    already in band and stops updating -- and must not block until move_timeout."""
+    async with init_devices(mock=True):
+        dev = Eurotherm3k(PREFIX, name="et")
+    dev.loop1.tolerance = 1.0
+    dev.loop1.settle_time = 0.2
+    dev.loop1.move_timeout = 5.0
+    # already in band and stable (no further updates arrive)
+    set_mock_value(dev.loop1.readback, 300.0)
+    start = time.monotonic()
+    await dev.loop1.set(300.0)
+    elapsed = time.monotonic() - start
+    # waited ~settle_time, and crucially did NOT hang until move_timeout
+    assert elapsed >= 0.2
+    assert elapsed < dev.loop1.move_timeout
+    get_mock_put(dev.loop1.setpoint).assert_called_once_with(300.0)
 
 
 @pytest.mark.asyncio

--- a/nslsii/tests/ophyd_async/test_eurotherm3k.py
+++ b/nslsii/tests/ophyd_async/test_eurotherm3k.py
@@ -1,0 +1,85 @@
+import pytest
+from ophyd_async.core import get_mock_put, init_devices, set_mock_value
+
+from nslsii.ophyd_async.devices import Eurotherm3k, Eurotherm3kControlMode
+
+PREFIX = "XF:28ID1-ES{ET:05}"
+
+
+@pytest.mark.asyncio
+async def test_pvs_are_addressed():
+    async with init_devices(mock=True):
+        dev = Eurotherm3k(PREFIX, name="et")
+    # child loop signals compose under <prefix>LOOPn:
+    assert dev.loop1.setpoint.source == f"mock+ca://{PREFIX}LOOP1:SP:RBV"
+    assert dev.loop1.readback.source == f"mock+ca://{PREFIX}LOOP1:PV:RBV"
+    assert dev.loop2.setpoint.source == f"mock+ca://{PREFIX}LOOP2:SP:RBV"
+    # global signal sits directly under the prefix
+    assert dev.programmer_status.source == f"mock+ca://{PREFIX}PROGSTAT:RBV"
+
+
+@pytest.mark.asyncio
+async def test_format_tags_route_signals():
+    async with init_devices(mock=True):
+        dev = Eurotherm3k(PREFIX, name="et")
+    reading = await dev.read()
+    config = await dev.read_configuration()
+    # HINTED readbacks (merged from both loop CHILDren) appear in read()
+    assert "et-loop1-readback" in reading
+    assert "et-loop2-readback" in reading
+    # CONFIG signals appear in read_configuration()
+    assert "et-loop1-ramp_rate" in config
+
+
+@pytest.mark.asyncio
+async def test_control_mode_enum_roundtrip():
+    async with init_devices(mock=True):
+        dev = Eurotherm3k(PREFIX, name="et")
+    await dev.loop1.control_mode.set(Eurotherm3kControlMode.MANUAL)
+    assert await dev.loop1.control_mode.get_value() is Eurotherm3kControlMode.MANUAL
+
+
+@pytest.mark.asyncio
+async def test_set_commands_setpoint_and_settles():
+    async with init_devices(mock=True):
+        dev = Eurotherm3k(PREFIX, name="et")
+    dev.loop1.tolerance = 1.0
+    dev.loop1.settle_time = 0.0
+    # pretend the controller is already at temperature
+    set_mock_value(dev.loop1.readback, 300.0)
+    await dev.loop1.set(300.0)  # returns => it settled
+    get_mock_put(dev.loop1.setpoint).assert_called_once()  # and it wrote the setpoint
+
+
+@pytest.mark.asyncio
+async def test_set_times_out_if_never_in_band():
+    async with init_devices(mock=True):
+        dev = Eurotherm3k(PREFIX, name="et")
+    dev.loop1.tolerance = 0.5
+    dev.loop1.move_timeout = 0.3  # keep the test fast
+    set_mock_value(dev.loop1.readback, 0.0)  # stays far from 300
+    with pytest.raises(TimeoutError):
+        await dev.loop1.set(300.0)
+
+
+# Legacy PDF eurotherm3k (pdf-profile-collection/startup/16-eurotherm_HAB.py):
+# each component -> the ophyd-async signal that must address the same PV.
+_LEGACY_PV_MAP = {
+    "setpoint": ("loop1", "setpoint", "LOOP1:SP:RBV"),
+    "readback": ("loop1", "readback", "LOOP1:PV:RBV"),
+    "working": ("loop1", "working_setpoint", "LOOP1:WSP:RBV"),
+    "output": ("loop1", "output", "LOOP1:O:RBV"),
+    "ramprate": ("loop1", "ramp_rate", "LOOP1:RR:RBV"),
+    "manual_mode": ("loop1", "control_mode", "LOOP1:MAN:RBV"),
+    "autotune": ("loop1", "autotune", "LOOP1:AUTOTUNE:RBV"),
+}
+
+
+@pytest.mark.asyncio
+async def test_legacy_pv_surface_equivalence():
+    """Every PV of the legacy PDF eurotherm3k is addressed identically here."""
+    async with init_devices(mock=True):
+        dev = Eurotherm3k(PREFIX, name="et")
+    for _legacy, (loop, attr, suffix) in _LEGACY_PV_MAP.items():
+        signal = getattr(getattr(dev, loop), attr)
+        assert signal.source == f"mock+ca://{PREFIX}{suffix}"


### PR DESCRIPTION
Add nslsii.ophyd_async.devices.eurotherm3k: Eurotherm3kLoop (a Movable PID loop with a settle-aware set()) plus a two-loop Eurotherm3k container and its StrictEnums, mapping the nsls2.ioc_deploy eurotherm3k IOC role. Export the new classes from the devices package and fix the pre-existing broken absolute 'from rbd9103 import ...' there (-> relative). Add mock-backend unit tests including a legacy PV-surface equivalence check against the classic Eurotherm, and add pytest-asyncio to the dev requirements.

Assisted-by: copilot:claude-opus-4-8